### PR TITLE
Split Coupling

### DIFF
--- a/src/DiffEqJump.jl
+++ b/src/DiffEqJump.jl
@@ -20,12 +20,15 @@ include("problem.jl")
 include("callbacks.jl")
 include("solve.jl")
 include("extended_jump_array.jl")
+include("coupling.jl")
 
 export AbstractJump, AbstractAggregatorAlgorithm, AbstractJumpAggregator, AbstractJumpProblem
 
 export ConstantRateJump, VariableRateJump, JumpSet, CompoundConstantRateJump
 
 export JumpProblem
+
+export SplitCoupledJumpProblem
 
 export Direct
 

--- a/src/DiffEqJump.jl
+++ b/src/DiffEqJump.jl
@@ -20,6 +20,7 @@ include("problem.jl")
 include("callbacks.jl")
 include("solve.jl")
 include("extended_jump_array.jl")
+include("coupled_array.jl")
 include("coupling.jl")
 
 export AbstractJump, AbstractAggregatorAlgorithm, AbstractJumpAggregator, AbstractJumpProblem

--- a/src/coupled_array.jl
+++ b/src/coupled_array.jl
@@ -1,0 +1,47 @@
+type CoupledArray{T,T2} <: AbstractArray{Float64,1}
+  u::T
+  u_control::T2
+  order::Bool
+end
+
+Base.length(A::CoupledArray) = length(A.u) + length(A.u_control)
+Base.size(A::CoupledArray) = (length(A),)
+function Base.getindex(A::CoupledArray,i::Int)
+  if A.order == true
+    i <= length(A.u) ? A.u[i] : A.u_control[i-length(A.u)]
+  else
+    i <= length(A.u) ? A.u_control[i] : A.u[i-length(A.u)]
+  end
+end
+
+function Base.getindex(A::CoupledArray,I...)
+  A[sub2ind(A.u,I...)]
+end
+
+function Base.getindex(A::CoupledArray,I::CartesianIndex{1})
+  A[I[1]]
+end
+
+Base.setindex!(A::CoupledArray,v,I...) = (A[sub2ind(A.u,I...)] = v)
+Base.setindex!(A::CoupledArray,v,I::CartesianIndex{1}) = (A[I[1]] = v)
+function Base.setindex!(A::CoupledArray,v,i::Int)
+  if A.order == true
+    i <= length(A.u) ? (A.u[i] = v) : (A.u_control[i-length(A.u)] = v)
+  else
+    i <= length(A.u) ? (A.u_control[i] = v) : (A.u[i-length(A.u)] = v)
+  end
+end
+
+linearindexing{T<:CoupledArray}(::Type{T}) = Base.LinearFast()
+similar(A::CoupledArray) = deepcopy(A)
+
+
+function recursivecopy!{T<:CoupledArray}(dest::T, src::T)
+  recursivecopy!(dest.u,src.u)
+  recursivecopy!(dest.u_control,src.u_control)
+end
+
+display(A::CoupledArray) = display(A.u)
+show(A::CoupledArray) = show(A.u)
+plot_indices(A::CoupledArray) = eachindex(A)
+flip_u!(A::CoupledArray) = (A.order = !A.order)

--- a/src/coupled_array.jl
+++ b/src/coupled_array.jl
@@ -39,6 +39,7 @@ similar(A::CoupledArray) = deepcopy(A)
 function recursivecopy!{T<:CoupledArray}(dest::T, src::T)
   recursivecopy!(dest.u,src.u)
   recursivecopy!(dest.u_control,src.u_control)
+  dest.order = src.order
 end
 
 display(A::CoupledArray) = display(A.u)

--- a/src/coupling.jl
+++ b/src/coupling.jl
@@ -1,15 +1,62 @@
 SplitCoupledJumpProblem(prob::AbstractJumpProblem,prob_control::AbstractJumpProblem,aggregator::AbstractAggregatorAlgorithm,coupling_map::Vector{Tuple{Int64,Int64}})= JumpProblem(cat_problems(prob,prob_control),aggregator,build_split_jumps(prob,prob_control,coupling_map)...)
 
+type CoupledArray{T,T2} <: AbstractArray{Float64,1}
+  u::T
+  u_control::T2
+  order::Bool
+end
+
+Base.length(A::CoupledArray) = length(A.u) + length(A.u_control)
+Base.size(A::CoupledArray) = (length(A),)
+function Base.getindex(A::CoupledArray,i::Int)
+  if A.order == true
+    i <= length(A.u) ? A.u[i] : A.u_control[i-length(A.u)]
+  else
+    i <= length(A.u) ? A.u_control[i] : A.u[i-length(A.u)]
+  end
+end
+function Base.getindex(A::CoupledArray,I...)
+  A[sub2ind(A.u,I...)]
+end
+function Base.getindex(A::CoupledArray,I::CartesianIndex{1})
+  A[I[1]]
+end
+Base.setindex!(A::CoupledArray,v,I...) = (A[sub2ind(A.u,I...)] = v)
+Base.setindex!(A::CoupledArray,v,I::CartesianIndex{1}) = (A[I[1]] = v)
+function Base.setindex!(A::CoupledArray,v,i::Int)
+  if A.order == true
+    i <= length(A.u) ? (A.u[i] = v) : (A.u_control[i-length(A.u)] = v)
+  else
+    i <= length(A.u) ? (A.u_control[i] = v) : (A.u[i-length(A.u)] = v)
+  end
+end
+
+linearindexing{T<:CoupledArray}(::Type{T}) = Base.LinearFast()
+similar(A::CoupledArray) = deepcopy(A)
+
+
+function recursivecopy!{T<:CoupledArray}(dest::T, src::T)
+  recursivecopy!(dest.u,src.u)
+  recursivecopy!(dest.u_control,src.u_control)
+end
+
+display(A::CoupledArray) = display(A.u)
+show(A::CoupledArray) = show(A.u)
+plot_indices(A::CoupledArray) = eachindex(A.u)
+flip_u!(A::CoupledArray) = (A.order = !A.order)
+
+
 # make new discrete problem by joining initial_data
 function cat_problems(prob::AbstractJumpProblem,prob_control::AbstractJumpProblem)
-  coupled_u0 = cat(1,prob.prob.u0,prob_control.prob.u0)
-  DiscreteProblem(coupled_u0,prob.prob.tspan)
+  u0_coupled = CoupledArray(prob.prob.u0,prob_control.prob.u0,true)
+  DiscreteProblem(u0_coupled,prob.prob.tspan)
 end
 
 function build_split_jumps(prob::AbstractJumpProblem,prob_control::AbstractJumpProblem,coupling_map::Vector{Tuple{Int64,Int64}})
   num_jumps = length(prob.discrete_jump_aggregation.rates)
   d = length(prob.prob.u0)
   jumps = []
+  # overallocates, will fix later
   uncoupled = deleteat!(Vector(1:num_jumps),[c[1] for c in coupling_map ])
   uncoupled_control = deleteat!(Vector(1:num_jumps),[c[2] for c in coupling_map ])
   for c in uncoupled   # make uncoupled jumps in prob
@@ -22,9 +69,9 @@ function build_split_jumps(prob::AbstractJumpProblem,prob_control::AbstractJumpP
     new_rate = (t,u)->rate(t,u[d+1:2*d])
     affect! = prob_control.discrete_jump_aggregation.affects![c]
     new_affect! = function (integrator)
-        flip_u!(integrator)
+        flip_u!(integrator.u)
         affect!(integrator)
-        flip_u!(integrator)
+        flip_u!(integrator.u)
     end
     append!(jumps,[ConstantRateJump(new_rate,new_affect!)])
   end
@@ -37,32 +84,24 @@ function build_split_jumps(prob::AbstractJumpProblem,prob_control::AbstractJumpP
     # shared jump
     new_affect! = function (integrator)
         affect!(integrator)
-        flip_u!(integrator)
+        flip_u!(integrator.u)
         affect_control!(integrator)
-        flip_u!(integrator)
+        flip_u!(integrator.u)
     end
-    new_rate = (t,u)->min(rate(t,u),rate_control(t,u[d+1:2*d]))
+    new_rate = (t,u)->min(rate(t,u.u),rate_control(t,u.u_control))
     push!(jumps,ConstantRateJump(new_rate,new_affect!))
      # only prob
     new_affect! = affect!
-    new_rate = (t,u)->rate(t,u)-min(rate(t,u),rate_control(t,u[d+1:2*d]))
+    new_rate = (t,u)->rate(t,u.u)-min(rate(t,u.u),rate_control(t,u.u_control))
     push!(jumps,ConstantRateJump(new_rate,new_affect!))
     # only prob_control
     new_affect! = function (integrator)
-        flip_u!(integrator)
+        flip_u!(integrator.u)
         affect!(integrator)
-        flip_u!(integrator)
+        flip_u!(integrator.u)
     end
-    new_rate = (t,u)->rate_control(t,u[d+1:2*d])-min(rate(t,u),rate_control(t,u[d+1:2*d]))
+    new_rate = (t,u)->rate_control(t,u.u)-min(rate(t,u.u),rate_control(t,u.u_control))
     push!(jumps,ConstantRateJump(new_rate,new_affect!))
   end
   jumps
-end
-
-# flip positions of u in integrator so that affects can be applied
-# is there a better way to build new affects from old ones?
-flip_u! =  function (integrator)
-  d = length(integrator.u)
-  halfd = Int(d//2)
-  integrator.u[1:halfd],integrator.u[halfd+1:d] = integrator.u[halfd+1:d],integrator.u[1:halfd]
 end

--- a/src/coupling.jl
+++ b/src/coupling.jl
@@ -57,8 +57,24 @@ function cat_problems(prob::AbstractSDEProblem,prob_control::AbstractODEProblem)
   SDEProblem(new_f,new_g,u0_coupled,prob.tspan)
 end
 
+function cat_problems(prob::AbstractSDEProblem,prob_control::DiscreteProblem)
+  l = length(prob.u0)
+  new_f = function (t,u,du)
+    prob.f(t,u.u,@view du[1:l])
+    prob_control.f(t,u.u_control,@view du[l+1:2*l])
+  end
+  new_g = function (t,u,du)
+    prob.g(t,u.u,@view du[1:l])
+    for i in l+1:2*l
+      du[i] = 0.
+    end
+  end
+  u0_coupled = CoupledArray(prob.u0,prob_control.u0,true)
+  SDEProblem(new_f,new_g,u0_coupled,prob.tspan)
+end
+
 cat_problems(prob_control::AbstractODEProblem,prob::DiscreteProblem) = cat_problems(prob,prob_control)
-cat_problems(prob_control::AbstractSDEProblem,prob::DiscreteProblem) = cat_problems(prob,prob_control)
+cat_problems(prob_control::DiscreteProblem,prob::AbstractSDEProblem) = cat_problems(prob,prob_control)
 cat_problems(prob_control::AbstractODEProblem,prob::AbstractSDEProblem) = cat_problems(prob,prob_control)
 
 

--- a/src/coupling.jl
+++ b/src/coupling.jl
@@ -15,12 +15,15 @@ function Base.getindex(A::CoupledArray,i::Int)
     i <= length(A.u) ? A.u_control[i] : A.u[i-length(A.u)]
   end
 end
+
 function Base.getindex(A::CoupledArray,I...)
   A[sub2ind(A.u,I...)]
 end
+
 function Base.getindex(A::CoupledArray,I::CartesianIndex{1})
   A[I[1]]
 end
+
 Base.setindex!(A::CoupledArray,v,I...) = (A[sub2ind(A.u,I...)] = v)
 Base.setindex!(A::CoupledArray,v,I::CartesianIndex{1}) = (A[I[1]] = v)
 function Base.setindex!(A::CoupledArray,v,i::Int)
@@ -54,7 +57,6 @@ end
 
 function build_split_jumps(prob::AbstractJumpProblem,prob_control::AbstractJumpProblem,coupling_map::Vector{Tuple{Int64,Int64}})
   num_jumps = length(prob.discrete_jump_aggregation.rates)
-  d = length(prob.prob.u0)
   jumps = []
   # overallocates, will fix later
   uncoupled = deleteat!(Vector(1:num_jumps),[c[1] for c in coupling_map ])
@@ -66,7 +68,7 @@ function build_split_jumps(prob::AbstractJumpProblem,prob_control::AbstractJumpP
   end
   for c in uncoupled_control  # make uncoupled jumps in prob_control
     rate = prob_control.discrete_jump_aggregation.rates[c]
-    new_rate = (t,u)->rate(t,u[d+1:2*d])
+    new_rate = (t,u)->rate(t,u.u_control)
     affect! = prob_control.discrete_jump_aggregation.affects![c]
     new_affect! = function (integrator)
         flip_u!(integrator.u)

--- a/src/coupling.jl
+++ b/src/coupling.jl
@@ -62,8 +62,6 @@ cat_problems(prob_control::AbstractSDEProblem,prob::DiscreteProblem) = cat_probl
 cat_problems(prob_control::AbstractODEProblem,prob::AbstractSDEProblem) = cat_problems(prob,prob_control)
 
 
-
-
 # this only depends on the jumps in prob, not prob.prob
 function build_split_jumps(prob::AbstractJumpProblem,prob_control::AbstractJumpProblem,coupling_map::Vector{Tuple{Int64,Int64}})
   num_jumps = length(prob.discrete_jump_aggregation.rates)

--- a/src/coupling.jl
+++ b/src/coupling.jl
@@ -1,0 +1,68 @@
+SplitCoupledJumpProblem(prob::AbstractJumpProblem,prob_control::AbstractJumpProblem,aggregator::AbstractAggregatorAlgorithm,coupling_map::Vector{Tuple{Int64,Int64}})= JumpProblem(cat_problems(prob,prob_control),aggregator,build_split_jumps(prob,prob_control,coupling_map)...)
+
+# make new discrete problem by joining initial_data
+function cat_problems(prob::AbstractJumpProblem,prob_control::AbstractJumpProblem)
+  coupled_u0 = cat(1,prob.prob.u0,prob_control.prob.u0)
+  DiscreteProblem(coupled_u0,prob.prob.tspan)
+end
+
+function build_split_jumps(prob::AbstractJumpProblem,prob_control::AbstractJumpProblem,coupling_map::Vector{Tuple{Int64,Int64}})
+  num_jumps = length(prob.discrete_jump_aggregation.rates)
+  d = length(prob.prob.u0)
+  jumps = []
+  uncoupled = deleteat!(Vector(1:num_jumps),[c[1] for c in coupling_map ])
+  uncoupled_control = deleteat!(Vector(1:num_jumps),[c[2] for c in coupling_map ])
+  for c in uncoupled   # make uncoupled jumps in prob
+    new_rate = prob.discrete_jump_aggregation.rates[c]
+    new_affect! = prob.discrete_jump_aggregation.affects![c]
+    append!(jumps,[ConstantRateJump(new_rate,new_affect!)])
+  end
+  for c in uncoupled_control  # make uncoupled jumps in prob_control
+    rate = prob_control.discrete_jump_aggregation.rates[c]
+    new_rate = (t,u)->rate(t,u[d+1:2*d])
+    affect! = prob_control.discrete_jump_aggregation.affects![c]
+    new_affect! = function (integrator)
+        flip_u!(integrator)
+        affect!(integrator)
+        flip_u!(integrator)
+    end
+    append!(jumps,[ConstantRateJump(new_rate,new_affect!)])
+  end
+
+  for c in coupling_map # make coupled jumps. 3 new jumps for each old one
+    rate = prob.discrete_jump_aggregation.rates[c[1]]
+    rate_control = prob_control.discrete_jump_aggregation.rates[c[2]]
+    affect! = prob.discrete_jump_aggregation.affects![c[1]]
+    affect_control! = prob_control.discrete_jump_aggregation.affects![c[2]]
+    # shared jump
+    new_affect! = function (integrator)
+        affect!(integrator)
+        flip_u!(integrator)
+        affect_control!(integrator)
+        flip_u!(integrator)
+    end
+    new_rate = (t,u)->min(rate(t,u),rate_control(t,u[d+1:2*d]))
+    push!(jumps,ConstantRateJump(new_rate,new_affect!))
+     # only prob
+    new_affect! = affect!
+    new_rate = (t,u)->rate(t,u)-min(rate(t,u),rate_control(t,u[d+1:2*d]))
+    push!(jumps,ConstantRateJump(new_rate,new_affect!))
+    # only prob_control
+    new_affect! = function (integrator)
+        flip_u!(integrator)
+        affect!(integrator)
+        flip_u!(integrator)
+    end
+    new_rate = (t,u)->rate_control(t,u[d+1:2*d])-min(rate(t,u),rate_control(t,u[d+1:2*d]))
+    push!(jumps,ConstantRateJump(new_rate,new_affect!))
+  end
+  jumps
+end
+
+# flip positions of u in integrator so that affects can be applied
+# is there a better way to build new affects from old ones?
+flip_u! =  function (integrator)
+  d = length(integrator.u)
+  halfd = Int(d//2)
+  integrator.u[1:halfd],integrator.u[halfd+1:d] = integrator.u[halfd+1:d],integrator.u[1:halfd]
+end

--- a/src/coupling.jl
+++ b/src/coupling.jl
@@ -19,7 +19,7 @@ end
 function cat_problems(prob::DiscreteProblem,prob_control::AbstractODEProblem)
   l = length(prob.u0) # add l_c = length(prob_control.u0)
   if !(typeof(prob.f) <: typeof(DiffEqBase.DISCRETE_INPLACE_DEFAULT))
-    warn("Coupling to DiscreteProblem with nontrivial f.")
+    warn("Coupling to DiscreteProblem with nontrivial f. Note that, unless scale_by_time=true, the meaning of f will change when using an ODE/SDE/DDE/DAE solver.")
   end
   new_f = function (t,u,du)
     prob.f(t,u.u,@view du[1:l])
@@ -63,7 +63,7 @@ end
 function cat_problems(prob::AbstractSDEProblem,prob_control::DiscreteProblem)
   l = length(prob.u0)
   if !(typeof(prob_control.f) <: typeof(DiffEqBase.DISCRETE_INPLACE_DEFAULT))
-    warn("Coupling to DiscreteProblem with nontrivial f.")
+    warn("Coupling to DiscreteProblem with nontrivial f. Note that, unless scale_by_time=true, the meaning of f will change when using an ODE/SDE/DDE/DAE solver.")
   end
   new_f = function (t,u,du)
     prob.f(t,u.u,@view du[1:l])

--- a/src/coupling.jl
+++ b/src/coupling.jl
@@ -19,7 +19,9 @@ end
 function cat_problems(prob::DiscreteProblem,prob_control::AbstractODEProblem)
   l = length(prob.u0) # add l_c = length(prob_control.u0)
   new_f = function (t,u,du)
-    prob.f(t,u.u,@view du[1:l])
+    for i in 1:l # inbounds here?
+      du[i] = 0.
+    end
     prob_control.f(t,u.u_control,@view du[l+1:2*l])
   end
   u0_coupled = CoupledArray(prob.u0,prob_control.u0,true)
@@ -61,7 +63,9 @@ function cat_problems(prob::AbstractSDEProblem,prob_control::DiscreteProblem)
   l = length(prob.u0)
   new_f = function (t,u,du)
     prob.f(t,u.u,@view du[1:l])
-    prob_control.f(t,u.u_control,@view du[l+1:2*l])
+    for i in l+1:2*l
+      du[i] = 0.
+    end
   end
   new_g = function (t,u,du)
     prob.g(t,u.u,@view du[1:l])

--- a/src/coupling.jl
+++ b/src/coupling.jl
@@ -1,70 +1,81 @@
-SplitCoupledJumpProblem(prob::AbstractJumpProblem,prob_control::AbstractJumpProblem,aggregator::AbstractAggregatorAlgorithm,coupling_map::Vector{Tuple{Int64,Int64}})= JumpProblem(cat_problems(prob,prob_control),aggregator,build_split_jumps(prob,prob_control,coupling_map)...)
+SplitCoupledJumpProblem(prob::AbstractJumpProblem,prob_control::AbstractJumpProblem,aggregator::AbstractAggregatorAlgorithm,coupling_map::Vector{Tuple{Int64,Int64}})= JumpProblem(cat_problems(prob.prob,prob_control.prob),aggregator,build_split_jumps(prob,prob_control,coupling_map)...)
 
-type CoupledArray{T,T2} <: AbstractArray{Float64,1}
-  u::T
-  u_control::T2
-  order::Bool
+# make new problem by joining initial_data
+function cat_problems(prob::DiscreteProblem,prob_control::DiscreteProblem)
+  u0_coupled = CoupledArray(prob.u0,prob_control.u0,true)
+  DiscreteProblem(u0_coupled,prob.tspan)
 end
 
-Base.length(A::CoupledArray) = length(A.u) + length(A.u_control)
-Base.size(A::CoupledArray) = (length(A),)
-function Base.getindex(A::CoupledArray,i::Int)
-  if A.order == true
-    i <= length(A.u) ? A.u[i] : A.u_control[i-length(A.u)]
-  else
-    i <= length(A.u) ? A.u_control[i] : A.u[i-length(A.u)]
+function cat_problems(prob::AbstractODEProblem,prob_control::AbstractODEProblem)
+  l = length(prob.u0) # add l_c = length(prob_control.u0)
+  new_f = function (t,u,du)
+    prob.f(t,u.u,@view du[1:l])
+    prob_control.f(t,u.u_control,@view du[l+1:2*l])
   end
+  u0_coupled = CoupledArray(prob.u0,prob_control.u0,true)
+  ODEProblem(new_f,u0_coupled,prob.tspan)
 end
 
-function Base.getindex(A::CoupledArray,I...)
-  A[sub2ind(A.u,I...)]
-end
-
-function Base.getindex(A::CoupledArray,I::CartesianIndex{1})
-  A[I[1]]
-end
-
-Base.setindex!(A::CoupledArray,v,I...) = (A[sub2ind(A.u,I...)] = v)
-Base.setindex!(A::CoupledArray,v,I::CartesianIndex{1}) = (A[I[1]] = v)
-function Base.setindex!(A::CoupledArray,v,i::Int)
-  if A.order == true
-    i <= length(A.u) ? (A.u[i] = v) : (A.u_control[i-length(A.u)] = v)
-  else
-    i <= length(A.u) ? (A.u_control[i] = v) : (A.u[i-length(A.u)] = v)
+function cat_problems(prob::DiscreteProblem,prob_control::AbstractODEProblem)
+  l = length(prob.u0) # add l_c = length(prob_control.u0)
+  new_f = function (t,u,du)
+    prob.f(t,u.u,@view du[1:l])
+    prob_control.f(t,u.u_control,@view du[l+1:2*l])
   end
+  u0_coupled = CoupledArray(prob.u0,prob_control.u0,true)
+  ODEProblem(new_f,u0_coupled,prob.tspan)
 end
 
-linearindexing{T<:CoupledArray}(::Type{T}) = Base.LinearFast()
-similar(A::CoupledArray) = deepcopy(A)
 
-
-function recursivecopy!{T<:CoupledArray}(dest::T, src::T)
-  recursivecopy!(dest.u,src.u)
-  recursivecopy!(dest.u_control,src.u_control)
+function cat_problems(prob::AbstractSDEProblem,prob_control::AbstractSDEProblem)
+  l = length(prob.u0)
+  new_f = function (t,u,du)
+    prob.f(t,u.u,@view du[1:l])
+    prob_control.f(t,u.u_control,@view du[l+1:2*l])
+  end
+  new_g = function (t,u,du)
+    prob.g(t,u.u,@view du[1:l])
+    prob_control.g(t,u.u_control,@view du[l+1:2*l])
+  end
+  u0_coupled = CoupledArray(prob.u0,prob_control.u0,true)
+  SDEProblem(new_f,new_g,u0_coupled,prob.tspan)
 end
 
-display(A::CoupledArray) = display(A.u)
-show(A::CoupledArray) = show(A.u)
-plot_indices(A::CoupledArray) = eachindex(A.u)
-flip_u!(A::CoupledArray) = (A.order = !A.order)
-
-
-# make new discrete problem by joining initial_data
-function cat_problems(prob::AbstractJumpProblem,prob_control::AbstractJumpProblem)
-  u0_coupled = CoupledArray(prob.prob.u0,prob_control.prob.u0,true)
-  DiscreteProblem(u0_coupled,prob.prob.tspan)
+function cat_problems(prob::AbstractSDEProblem,prob_control::AbstractODEProblem)
+  l = length(prob.u0)
+  new_f = function (t,u,du)
+    prob.f(t,u.u,@view du[1:l])
+    prob_control.f(t,u.u_control,@view du[l+1:2*l])
+  end
+  new_g = function (t,u,du)
+    prob.g(t,u.u,@view du[1:l])
+    for i in l+1:2*l
+      du[i] = 0.
+    end
+  end
+  u0_coupled = CoupledArray(prob.u0,prob_control.u0,true)
+  SDEProblem(new_f,new_g,u0_coupled,prob.tspan)
 end
 
+cat_problems(prob_control::AbstractODEProblem,prob::DiscreteProblem) = cat_problems(prob,prob_control)
+cat_problems(prob_control::AbstractSDEProblem,prob::DiscreteProblem) = cat_problems(prob,prob_control)
+cat_problems(prob_control::AbstractODEProblem,prob::AbstractSDEProblem) = cat_problems(prob,prob_control)
+
+
+
+
+# this only depends on the jumps in prob, not prob.prob
 function build_split_jumps(prob::AbstractJumpProblem,prob_control::AbstractJumpProblem,coupling_map::Vector{Tuple{Int64,Int64}})
   num_jumps = length(prob.discrete_jump_aggregation.rates)
+  num_jumps_control = length(prob_control.discrete_jump_aggregation.rates)
   jumps = []
   # overallocates, will fix later
   uncoupled = deleteat!(Vector(1:num_jumps),[c[1] for c in coupling_map ])
-  uncoupled_control = deleteat!(Vector(1:num_jumps),[c[2] for c in coupling_map ])
+  uncoupled_control = deleteat!(Vector(1:num_jumps_control),[c[2] for c in coupling_map ])
   for c in uncoupled   # make uncoupled jumps in prob
     new_rate = prob.discrete_jump_aggregation.rates[c]
     new_affect! = prob.discrete_jump_aggregation.affects![c]
-    append!(jumps,[ConstantRateJump(new_rate,new_affect!)])
+    push!(jumps,ConstantRateJump(new_rate,new_affect!))
   end
   for c in uncoupled_control  # make uncoupled jumps in prob_control
     rate = prob_control.discrete_jump_aggregation.rates[c]
@@ -75,7 +86,7 @@ function build_split_jumps(prob::AbstractJumpProblem,prob_control::AbstractJumpP
         affect!(integrator)
         flip_u!(integrator.u)
     end
-    append!(jumps,[ConstantRateJump(new_rate,new_affect!)])
+    push!(jumps,ConstantRateJump(new_rate,new_affect!))
   end
 
   for c in coupling_map # make coupled jumps. 3 new jumps for each old one
@@ -102,7 +113,7 @@ function build_split_jumps(prob::AbstractJumpProblem,prob_control::AbstractJumpP
         affect!(integrator)
         flip_u!(integrator.u)
     end
-    new_rate = (t,u)->rate_control(t,u.u)-min(rate(t,u.u),rate_control(t,u.u_control))
+    new_rate = (t,u)->rate_control(t,u.u_control)-min(rate(t,u.u),rate_control(t,u.u_control))
     push!(jumps,ConstantRateJump(new_rate,new_affect!))
   end
   jumps

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,4 +3,5 @@ using DiffEqJump, DiffEqBase, Base.Test
 tic()
 @time @testset "Constant Rate Tests" begin include("constant_rate.jl") end
 @time @testset "Variable Rate Tests" begin include("variable_rate.jl") end
+@time @testset "Split Coupled Tests" begin include("splitcoupled.jl") end
 toc()

--- a/test/splitcoupled.jl
+++ b/test/splitcoupled.jl
@@ -8,8 +8,8 @@ affect! = function (integrator)
 end
 jump1 = ConstantRateJump(rate,affect!)
 
-prob = DiscreteProblem([10],(0.0,500.0))
-prob_control = DiscreteProblem([10],(0.0,500.0))
+prob = DiscreteProblem([10],(0.0,50.0))
+prob_control = DiscreteProblem([10],(0.0,50.0))
 
 jump_prob = JumpProblem(prob,Direct(),jump1)
 jump_prob_control = JumpProblem(prob_control,Direct(),jump1)

--- a/test/splitcoupled.jl
+++ b/test/splitcoupled.jl
@@ -1,10 +1,10 @@
-using DiffEqJump, DiffEqBase, OrdinaryDiffEq
+using DiffEqJump, DiffEqBase, OrdinaryDiffEq, StochasticDiffEq
 using Base.Test
 
 
-rate = (t,u) -> 100.*u[1]
+rate = (t,u) -> 1.*u[1]
 affect! = function (integrator)
-  integrator.u[1] += 1
+  integrator.u[1] = 1.
 end
 jump1 = ConstantRateJump(rate,affect!)
 
@@ -20,3 +20,48 @@ coupled_prob = SplitCoupledJumpProblem(jump_prob,jump_prob_control,Direct(),coup
 @time sol =  solve(coupled_prob,Discrete(apply_map=false))
 @time solve(jump_prob,Discrete(apply_map=false))
 @test [s[1]-s[2] for s in sol.u] == zeros(length(sol.t)) # coupling two copies of the same process should give zero
+
+
+rate = (t,u) -> 1.
+affect! = function (integrator)
+  integrator.u[1] = 1.
+end
+jump1 = ConstantRateJump(rate,affect!)
+rate = (t,u) -> 2.
+jump2 = ConstantRateJump(rate,affect!)
+
+f = function (t,u,du)
+  du[1] = u[1]
+end
+g = function (t,u,du)
+  du[1] = 0.1
+end
+
+# Jump ODE to jump ODE
+prob = ODEProblem(f,[1.],(0.0,1.0))
+prob_control = ODEProblem(f,[1.],(0.0,1.0))
+jump_prob = JumpProblem(prob,Direct(),jump1)
+jump_prob_control = JumpProblem(prob_control,Direct(),jump2)
+coupled_prob = SplitCoupledJumpProblem(jump_prob,jump_prob_control,Direct(),coupling_map)
+sol =  solve(coupled_prob,Tsit5())
+@test mean([abs(s[1]-s[2]) for s in sol.u])<=5.
+
+
+# Jump SDE to Jump SDE
+prob = SDEProblem(f,g,[1.],(0.0,1.0))
+prob_control = SDEProblem(f,g,[1.],(0.0,1.0))
+jump_prob = JumpProblem(prob,Direct(),jump1)
+jump_prob_control = JumpProblem(prob_control,Direct(),jump1)
+coupled_prob = SplitCoupledJumpProblem(jump_prob,jump_prob_control,Direct(),coupling_map)
+sol =  solve(coupled_prob,SRIW1())
+@test mean([abs(s[1]-s[2]) for s in sol.u])<=5.
+
+
+# Jump SDE to Jump ODE
+prob = ODEProblem(f,[1.,1.,0.],(0.0,1.0))
+prob_control = SDEProblem(f,g,[1.,1.,0.],(0.0,1.0))
+jump_prob = JumpProblem(prob,Direct(),jump1)
+jump_prob_control = JumpProblem(prob_control,Direct(),jump1)
+coupled_prob = SplitCoupledJumpProblem(jump_prob,jump_prob_control,Direct(),coupling_map)
+sol =  solve(coupled_prob,SRIW1())
+@test mean([abs(s[1]-s[2]) for s in sol.u])<=5.

--- a/test/splitcoupled.jl
+++ b/test/splitcoupled.jl
@@ -58,10 +58,22 @@ sol =  solve(coupled_prob,SRIW1())
 
 
 # Jump SDE to Jump ODE
-prob = ODEProblem(f,[1.,1.,0.],(0.0,1.0))
-prob_control = SDEProblem(f,g,[1.,1.,0.],(0.0,1.0))
+prob = ODEProblem(f,[1.],(0.0,1.0))
+prob_control = SDEProblem(f,g,[1.],(0.0,1.0))
 jump_prob = JumpProblem(prob,Direct(),jump1)
 jump_prob_control = JumpProblem(prob_control,Direct(),jump1)
 coupled_prob = SplitCoupledJumpProblem(jump_prob,jump_prob_control,Direct(),coupling_map)
 sol =  solve(coupled_prob,SRIW1())
 @test mean([abs(s[1]-s[2]) for s in sol.u])<=5.
+
+# Jump SDE to Discrete
+rate = (t,u) -> 1.
+affect! = function (integrator)
+  integrator.u[1] += 1.
+end
+prob = DiscreteProblem([1.],(0.0,1.0))
+prob_control = SDEProblem(f,g,[1.],(0.0,1.0))
+jump_prob = JumpProblem(prob,Direct(),jump1)
+jump_prob_control = JumpProblem(prob_control,Direct(),jump1)
+coupled_prob = SplitCoupledJumpProblem(jump_prob,jump_prob_control,Direct(),coupling_map)
+sol =  solve(coupled_prob,SRIW1())

--- a/test/splitcoupled.jl
+++ b/test/splitcoupled.jl
@@ -2,7 +2,7 @@ using DiffEqJump, DiffEqBase, OrdinaryDiffEq
 using Base.Test
 
 
-rate = (t,u) -> 1.0*u[1]
+rate = (t,u) -> 100.*u[1]
 affect! = function (integrator)
   integrator.u[1] += 1
 end

--- a/test/splitcoupled.jl
+++ b/test/splitcoupled.jl
@@ -1,0 +1,22 @@
+using DiffEqJump, DiffEqBase, OrdinaryDiffEq
+using Base.Test
+
+
+rate = (t,u) -> 1.0*u[1]
+affect! = function (integrator)
+  integrator.u[1] += 1
+end
+jump1 = ConstantRateJump(rate,affect!)
+
+prob = DiscreteProblem([10],(0.0,500.0))
+prob_control = DiscreteProblem([10],(0.0,500.0))
+
+jump_prob = JumpProblem(prob,Direct(),jump1)
+jump_prob_control = JumpProblem(prob_control,Direct(),jump1)
+
+coupling_map = [(1, 1)]
+coupled_prob = SplitCoupledJumpProblem(jump_prob,jump_prob_control,Direct(),coupling_map)
+
+@time sol =  solve(coupled_prob,Discrete(apply_map=false))
+@time solve(jump_prob,Discrete(apply_map=false))
+@test [s[1]-s[2] for s in sol.u] == zeros(length(sol.t)) # coupling two copies of the same process should give zero


### PR DESCRIPTION
Implementation of the split coupling between two `JumpProblem`s. Currently this only works for constant rates, but it should be possible to extend it. Note that this is independent of the aggregator, but other couplings may need to be associated with specific aggregators. 