### PR TITLE
add mass action jump type

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -4,4 +4,5 @@ RecursiveArrayTools
 Distributions
 RandomNumbers
 Compat 0.19.0
+FunctionWrappers 0.1.0
 Requires

--- a/src/DiffEqJump.jl
+++ b/src/DiffEqJump.jl
@@ -2,7 +2,7 @@ __precompile__()
 
 module DiffEqJump
 
-using DiffEqBase, Compat, Requires, Distributions, RandomNumbers
+using DiffEqBase, Compat, Requires, Distributions, RandomNumbers, FunctionWrappers
 
 import DiffEqBase: DiscreteCallback, init, solve, solve!, plot_indices
 import Base: size, getindex, setindex!, length, similar, indices, show
@@ -14,6 +14,7 @@ import RecursiveArrayTools: recursivecopy!
 @compat abstract type AbstractJumpAggregator end
 @compat abstract type AbstractJumpProblem{P,J} <: DEProblem end
 
+include("massaction_rates.jl")
 include("aggregators/aggregators.jl")
 include("aggregators/ssajump.jl")
 include("aggregators/direct.jl")
@@ -30,14 +31,14 @@ include("juno_rendering.jl")
 
 export AbstractJump, AbstractAggregatorAlgorithm, AbstractJumpAggregator, AbstractJumpProblem
 
-export ConstantRateJump, VariableRateJump, RegularJump,
+export ConstantRateJump, VariableRateJump, RegularJump, MassActionJump, 
        JumpSet, CompoundConstantRateJump
 
 export JumpProblem
 
 export SplitCoupledJumpProblem
 
-export Direct
+export Direct, DirectManyJumps
 
 export init, solve, solve!
 

--- a/src/aggregators/aggregators.jl
+++ b/src/aggregators/aggregators.jl
@@ -1,3 +1,5 @@
 struct Direct <: AbstractAggregatorAlgorithm end
+struct DirectManyJumps <: AbstractAggregatorAlgorithm end 
+
 # For JumpProblem construction without an aggregator
 struct NullAggregator <: AbstractAggregatorAlgorithm end

--- a/src/aggregators/direct.jl
+++ b/src/aggregators/direct.jl
@@ -1,9 +1,10 @@
-type DirectJumpAggregation{T,F1,F2,RNG} <: AbstractSSAJumpAggregator
+mutable struct DirectJumpAggregation{T,S,F1,F2,RNG} <: AbstractSSAJumpAggregator
   next_jump::Int
   next_jump_time::T
   end_time::T
   cur_rates::Vector{T}
   sum_rate::T
+  ma_jumps::S
   rates::F1
   affects!::F2
   save_positions::Tuple{Bool,Bool}
@@ -34,16 +35,26 @@ end
 
 ############################# Required Functions #############################
 
-# creating the JumpAggregation structure
-function aggregate(aggregator::Direct, u, p, t, end_time, constant_jumps, save_positions, rng)
-  rates = ((c.rate for c in constant_jumps)...)
-  affects! = ((c.affect! for c in constant_jumps)...)
-  cur_rates = Vector{typeof(t)}(length(rates))
-  sum_rate = zero(typeof(t))
-  next_jump = 0
-  next_jump_time = typemax(typeof(t))
-  DirectJumpAggregation(next_jump, next_jump_time, end_time, cur_rates,
-    sum_rate, rates, affects!, save_positions, rng)
+# creating the JumpAggregation structure (tuple-based constant jumps)
+function aggregate(aggregator::Direct, u, p, t, end_time, constant_jumps, 
+                    ma_jumps, save_positions, rng)
+
+  # handle constant jumps using function wrappers
+  rates, affects! = get_jump_info_tuples(constant_jumps)
+
+  build_jump_aggregation(u, p, t, end_time, ma_jumps, rates, affects!, 
+                          save_positions, rng)
+end
+
+# creating the JumpAggregation structure (function wrapper-based constant jumps)
+function aggregate(aggregator::DirectManyJumps, u, p, t, end_time, constant_jumps, 
+                    ma_jumps, save_positions, rng)
+
+  # handle constant jumps using function wrappers
+  rates, affects! = get_jump_info_fwrappers(u, p, t, constant_jumps)
+
+  build_jump_aggregation(u, p, t, end_time, ma_jumps, rates, affects!, 
+                          save_positions, rng)
 end
 
 # set up a new simulation and calculate the first jump / jump time
@@ -54,8 +65,13 @@ end
 
 # execute one jump, changing the system state
 @inline function execute_jumps!(p::DirectJumpAggregation, integrator, u, params, t)
-  idx = p.next_jump
-  @inbounds p.affects![idx](integrator)
+  num_ma_rates = length(p.ma_jumps.scaled_rates)
+  if p.next_jump <= num_ma_rates
+      @inbounds executerx!(u, p.ma_jumps.net_stoch[p.next_jump])
+  else
+      idx = p.next_jump - num_ma_rates
+      @inbounds p.affects![idx](integrator)
+  end
   nothing
 end
 
@@ -67,16 +83,55 @@ function generate_jumps!(p::DirectJumpAggregation, integrator, u, params, t)
   nothing
 end
 
+
 ######################## SSA specific helper routines ########################
 
-@fastmath function time_to_next_jump(p::DirectJumpAggregation, u, params, t)
-  cur_rates = p.cur_rates
-  rates = p.rates
+function build_jump_aggregation(u, p, t, end_time, ma_jumps, rates, affects!, 
+                                save_positions, rng)
 
-  fill_cur_rates(u, params, t, cur_rates, 1, rates...)
-  @inbounds for i in 2:length(cur_rates) # normalize for choice, cumsum
-    cur_rates[i] = cur_rates[i] + cur_rates[i-1]
+  # mass action jumps
+  majumps = ma_jumps
+  if majumps == nothing
+    majumps = MassActionJump(Vector{typeof(t)}(),
+                             Vector{Vector{Pair{Int,eltype(u)}}}(),
+                             Vector{Vector{Pair{Int,eltype(u)}}}() )
   end
+
+  # current jump rates, allows mass action rates and constant jumps
+  cur_rates = Vector{typeof(t)}(length(majumps.scaled_rates) + length(rates))
+
+  sum_rate = zero(typeof(t))
+  next_jump = 0
+  next_jump_time = typemax(typeof(t))
+  DirectJumpAggregation(next_jump, next_jump_time, end_time, cur_rates, sum_rate, 
+                        majumps, rates, affects!, save_positions, rng)
+end
+
+
+# tuple-based constant jumps
+@fastmath function time_to_next_jump(p::DirectJumpAggregation{T,S,F1,F2,RNG}, u, params, t) where {T,S,F1 <: Tuple, F2 <: Tuple, RNG}
+  prev_rate = zero(t)
+  new_rate  = zero(t)
+  cur_rates = p.cur_rates
+
+  # mass action rates
+  majumps   = p.ma_jumps
+  idx       = length(majumps.scaled_rates)
+  @inbounds for i in 1:idx
+    new_rate     = evalrxrate(u, majumps.scaled_rates[i], majumps.reactant_stoch[i])
+    cur_rates[i] = new_rate + prev_rate
+    prev_rate    = cur_rates[i]
+  end
+  
+  # constant jump rates  
+  idx  += 1
+  rates = p.rates
+  fill_cur_rates(u, params, t, cur_rates, idx, rates...)
+  @inbounds for i in idx:length(cur_rates)
+    cur_rates[i] = cur_rates[i] + prev_rate
+    prev_rate    = cur_rates[i]
+  end
+
   @inbounds sum_rate = cur_rates[end]
   sum_rate, randexp(p.rng) / sum_rate
 end
@@ -91,3 +146,34 @@ end
   @inbounds cur_rates[idx] = rate(u, p, t)
   nothing
 end
+
+
+# function wrapper-based constant jumps
+@fastmath function time_to_next_jump(p::DirectJumpAggregation{T,S,F1,F2,RNG}, u, params, t) where {T,S,F1 <: AbstractArray,F2 <: AbstractArray, RNG}
+  prev_rate = zero(t)
+  new_rate  = zero(t)
+  cur_rates = p.cur_rates
+
+  # mass action rates
+  majumps   = p.ma_jumps
+  idx       = length(majumps.scaled_rates)
+  @inbounds for i in 1:idx
+    new_rate     = evalrxrate(u, majumps.scaled_rates[i], majumps.reactant_stoch[i])
+    cur_rates[i] = new_rate + prev_rate
+    prev_rate    = cur_rates[i]
+  end
+
+  # constant jump rates
+  idx  += 1
+  rates = p.rates
+  @inbounds for i in 1:length(p.rates)
+    new_rate       = rates[i](u, params, t)
+    cur_rates[idx] = new_rate + prev_rate
+    prev_rate      = cur_rates[idx]
+    idx           += 1
+  end
+
+  @inbounds sum_rate = cur_rates[end]
+  sum_rate, randexp(p.rng) / sum_rate
+end
+

--- a/src/aggregators/direct.jl
+++ b/src/aggregators/direct.jl
@@ -39,7 +39,7 @@ end
 function aggregate(aggregator::Direct, u, p, t, end_time, constant_jumps, 
                     ma_jumps, save_positions, rng)
 
-  # handle constant jumps using function wrappers
+  # handle constant jumps using tuples
   rates, affects! = get_jump_info_tuples(constant_jumps)
 
   build_jump_aggregation(u, p, t, end_time, ma_jumps, rates, affects!, 
@@ -124,12 +124,14 @@ end
   end
   
   # constant jump rates  
-  idx  += 1
   rates = p.rates
-  fill_cur_rates(u, params, t, cur_rates, idx, rates...)
-  @inbounds for i in idx:length(cur_rates)
-    cur_rates[i] = cur_rates[i] + prev_rate
-    prev_rate    = cur_rates[i]
+  if !isempty(rates)
+    idx  += 1
+    fill_cur_rates(u, params, t, cur_rates, idx, rates...)
+    @inbounds for i in idx:length(cur_rates)
+      cur_rates[i] = cur_rates[i] + prev_rate
+      prev_rate    = cur_rates[i]
+    end
   end
 
   @inbounds sum_rate = cur_rates[end]

--- a/src/aggregators/ssajump.jl
+++ b/src/aggregators/ssajump.jl
@@ -7,6 +7,7 @@ An aggregator interface for SSA-like algorithms.
 - `end_time`
 - `cur_rates`
 - `sum_rate`
+- `ma_jumps`
 - `rates`
 - `affects!`
 - `save_positions`

--- a/src/jumps.jl
+++ b/src/jumps.jl
@@ -35,29 +35,86 @@ end
 RegularJump(rate,c,dc;mark_dist = nothing,constant_c = false) =
             RegularJump(rate,c,dc,mark_dist,constant_c)
 
-struct JumpSet{T1,T2,T3} <: AbstractJump
+
+struct MassActionJump{T,S} <: AbstractJump
+  scaled_rates::T
+  reactant_stoch::S
+  net_stoch::S
+
+  function MassActionJump{T,S}(rates::T, rs::S, ns::S, scale_rates::Bool) where {T,S}
+    sr = copy(rates)
+    if scale_rates && !isempty(sr) 
+      scalerates!(sr, rs)
+    end
+    new(sr, rs, ns)
+  end
+end
+MassActionJump(usr::T, rs::S, ns::S; scale_rates = true ) where {T,S} = MassActionJump{T,S}(usr, rs, ns, scale_rates)
+
+
+struct JumpSet{T1,T2,T3,T4} <: AbstractJump
   variable_jumps::T1
   constant_jumps::T2
   regular_jump::T3
+  massaction_jump::T4
 end
 
-JumpSet(jump::ConstantRateJump) = JumpSet((),(jump,),nothing)
-JumpSet(jump::VariableRateJump) = JumpSet((jump,),(),nothing)
-JumpSet(jump::RegularJump) = JumpSet((),(),jump)
-JumpSet() = JumpSet((),(),nothing)
+JumpSet(jump::ConstantRateJump) = JumpSet((),(jump,),nothing,nothing)
+JumpSet(jump::VariableRateJump) = JumpSet((jump,),(),nothing,nothing)
+JumpSet(jump::RegularJump)      = JumpSet((),(),jump,nothing)
+JumpSet(jump::MassActionJump)   = JumpSet((),(),nothing,jump)
+JumpSet() = JumpSet((),(),nothing,nothing)
 JumpSet(jb::Void) = JumpSet()
 
 # For Varargs, use recursion to make it type-stable
 
-JumpSet(jumps::AbstractJump...) = JumpSet(split_jumps((), (), nothing, jumps...)...)
+JumpSet(jumps::AbstractJump...) = JumpSet(split_jumps((), (), nothing, nothing, jumps...)...)
 
-@inline split_jumps(vj, cj, rj) = vj, cj, rj
-@inline split_jumps(vj, cj, rj, v::VariableRateJump, args...) = split_jumps((vj..., v), cj, rj, args...)
-@inline split_jumps(vj, cj, rj, c::ConstantRateJump, args...) = split_jumps(vj, (cj..., c), rj, args...)
-@inline split_jumps(vj, cj, rj, c::RegularJump, args...) = split_jumps(vj, cj, regular_jump_combine(rj,c), args...)
-@inline split_jumps(vj, cj, rj, j::JumpSet, args...) = split_jumps((vj...,j.variable_jumps...), (cj..., j.constant_jumps...), regular_jump_combine(rj,j.regular_jump), args...)
+@inline split_jumps(vj, cj, rj, maj) = vj, cj, rj, maj
+@inline split_jumps(vj, cj, rj, maj, v::VariableRateJump, args...) = split_jumps((vj..., v), cj, rj, maj, args...)
+@inline split_jumps(vj, cj, rj, maj, c::ConstantRateJump, args...) = split_jumps(vj, (cj..., c), rj, maj, args...)
+@inline split_jumps(vj, cj, rj, maj, c::RegularJump, args...) = split_jumps(vj, cj, regular_jump_combine(rj,c), maj, args...)
+@inline split_jumps(vj, cj, rj, maj, c::MassActionJump, args...) = split_jumps(vj, cj, rj, massaction_jump_combine(maj,c), args...)
+@inline split_jumps(vj, cj, rj, maj, j::JumpSet, args...) = split_jumps((vj...,j.variable_jumps...), 
+                                                                        (cj..., j.constant_jumps...), 
+                                                                        regular_jump_combine(rj,j.regular_jump), 
+                                                                        massaction_jump_combine(maj,j.massaction_jump), args...)
 
 regular_jump_combine(rj1::RegularJump,rj2::Void) = rj1
 regular_jump_combine(rj1::Void,rj2::RegularJump) = rj2
 regular_jump_combine(rj1::Void,rj2::Void) = rj1
 regular_jump_combine(rj1::RegularJump,rj2::RegularJump) = error("Only one regular jump is allowed in a JumpSet")
+
+massaction_jump_combine(maj1::MassActionJump, maj2::Void) = maj1
+massaction_jump_combine(maj1::Void, maj2::MassActionJump) = maj2
+massaction_jump_combine(maj1::Void, maj2::Void) = maj1
+massaction_jump_combine(maj1::MassActionJump, maj2::MassActionJump) = error("Only one mass action jump type is allowed in a JumpSet")
+
+
+##### helper methods for unpacking rates and affects! from constant jumps #####
+function get_jump_info_tuples(constant_jumps)
+  if (constant_jumps != nothing) && !isempty(constant_jumps)
+    rates    = ((c.rate for c in constant_jumps)...)
+    affects! = ((c.affect! for c in constant_jumps)...)
+  else
+    rates    = ()
+    affects! = ()
+  end
+  
+  rates, affects!
+end
+  
+function get_jump_info_fwrappers(u, p, t, constant_jumps)
+  RateWrapper   = FunctionWrappers.FunctionWrapper{typeof(t),Tuple{typeof(u), typeof(p), typeof(t)}}
+  AffectWrapper = FunctionWrappers.FunctionWrapper{Void,Tuple{Any}}
+
+  if (constant_jumps != nothing) && !isempty(constant_jumps)  
+    rates    = [RateWrapper(c.rate) for c in constant_jumps]
+    affects! = [AffectWrapper(x->(c.affect!(x);nothing)) for c in constant_jumps]
+  else
+    rates    = Vector{RateWrapper}()
+    affects! = Vector{AffectWrapper}()
+  end  
+
+  rates, affects!
+end

--- a/src/massaction_rates.jl
+++ b/src/massaction_rates.jl
@@ -1,0 +1,40 @@
+###############################################################################
+# Stochiometry for a given reaction is a vector of pairs mapping species id to 
+# stochiometric coefficient.
+###############################################################################
+
+@inbounds @fastmath function evalrxrate(speciesvec::AbstractVector{T}, rateconst,
+                                        stochmat::AbstractVector{Pair{T,T}})::typeof(rateconst) where T
+    val = one(T)
+
+    for specstoch in stochmat
+        specpop = speciesvec[specstoch[1]]
+        val    *= specpop
+        for k = 2:specstoch[2]
+            specpop -= one(specpop)
+            val     *= specpop
+        end
+    end
+
+    return rateconst * val
+end
+
+@inline @inbounds @fastmath function executerx!(speciesvec::AbstractVector{T},
+                                                net_stoch::AbstractVector{Pair{T,T}}) where T
+    for specstoch in net_stoch
+        speciesvec[specstoch[1]] += specstoch[2]
+    end
+    nothing
+end
+
+
+@inbounds function scalerates!(unscaled_rates, stochmat::Vector{Vector{Pair{T,T}}}) where T
+    for i in eachindex(unscaled_rates)
+        coef = one(T)
+        for specstoch in stochmat[i]            
+            coef *= factorial(specstoch[2])
+        end
+        unscaled_rates[i] /= coef
+    end
+    nothing
+end

--- a/test/linearreaction_test.jl
+++ b/test/linearreaction_test.jl
@@ -160,6 +160,10 @@ method = Direct()
 jump_prob_orig = A_to_B_mean_orig(Nrxs, method)
 push!(means, runSSAs(jump_prob_orig))
 
+# mass action through Direct()
+jump_prob_ma_notup = A_to_B_mean_ma(Nrxs, method)
+push!(means, runSSAs(jump_prob_ma_notup))
+
 # hybrid of tuples and mass action
 jump_prob_hybrid_orig = A_to_B_mean_hybrid(Nrxs, method)
 push!(means, runSSAs(jump_prob_hybrid_orig))
@@ -174,7 +178,7 @@ method = DirectManyJumps()
 jump_prob_fw = A_to_B_mean(Nrxs, method)
 push!(means, runSSAs(jump_prob_fw))
 
-# mass action
+# mass action through DirectManyJumps()
 jump_prob_ma = A_to_B_mean_ma(Nrxs, method)
 push!(means, runSSAs(jump_prob_ma))
 
@@ -199,6 +203,7 @@ end
 
 # if dobenchmark
 #     @btime runSSAs($jump_prob_orig)
+#     @btime runSSAs($jump_prob_ma_notup)
 #     @btime runSSAs($jump_prob_hybrid_orig)
 #     @btime runSSAs($jump_prob_fw)
 #     @btime runSSAs($jump_prob_ma)

--- a/test/linearreaction_test.jl
+++ b/test/linearreaction_test.jl
@@ -1,0 +1,207 @@
+# calculates the mean from N stochastic A->B reactions at different rates
+using DiffEqBase, DiffEqJump
+using Base.Test
+
+# using BenchmarkTools
+# dobenchmark = false
+
+doprint     = false
+dotest      = true
+Nrxs        = 16
+Nsims       = 8000
+tf          = .1
+baserate    = .1
+A0          = 100
+exactmean   = (t,ratevec) -> A0 * exp(-sum(ratevec) * t)
+
+rates = ones(Float64, Nrxs) * baserate;
+cumsum!(rates, rates)    
+
+function runSSAs(jump_prob)
+    Asamp = zeros(Int64,Nsims)
+    for i in 1:Nsims
+        sol = solve(jump_prob, SSAStepper())
+        Asamp[i] = sol[1,end]
+    end
+    mean(Asamp)
+end
+
+# uses constant jumps as a tuple within a JumpSet
+function A_to_B_mean_orig(N, method)
+    # jump reactions
+    jumpvec = []
+    for i in 1:N
+        ratefunc = (u,p,t) -> rates[i] * u[1]
+        affect!  = function (integrator)
+            integrator.u[1] -= 1
+            integrator.u[2] += 1
+        end
+        push!(jumpvec, ConstantRateJump(ratefunc, affect!))
+    end
+
+    # convert jumpvec to tuple to send to JumpProblem...
+    jumps     = ((jump for jump in jumpvec)...)
+    jset      = JumpSet((), jumps, nothing, nothing)
+    prob      = DiscreteProblem([A0,0], (0.0,tf))
+    jump_prob = JumpProblem(prob, method, jset; save_positions=(false,false))
+
+    jump_prob
+end
+
+# uses constant jumps as a vector within a JumpSet
+function A_to_B_mean(N, method)
+    # jump reactions
+    jumps = Vector{ConstantRateJump}()
+    for i in 1:N
+        ratefunc = (u,p,t) -> rates[i] * u[1]
+        affect!  = function (integrator)
+            integrator.u[1] -= 1
+            integrator.u[2] += 1
+        end
+        push!(jumps, ConstantRateJump(ratefunc, affect!))
+    end
+
+    # convert jumpvec to tuple to send to JumpProblem...
+    jset      = JumpSet((), jumps, nothing, nothing)
+    prob      = DiscreteProblem([A0,0], (0.0,tf))
+    jump_prob = JumpProblem(prob, method, jset; save_positions=(false,false))
+
+    jump_prob
+end
+
+# uses a mass action jump to represent all reactions
+function A_to_B_mean_ma(N, method)
+    reactstoch = Vector{Vector{Pair{Int64,Int64}}}();
+    netstoch   = Vector{Vector{Pair{Int64,Int64}}}();
+    for i = 1:N
+        push!(reactstoch,[1 => 1])
+        push!(netstoch,[1 => -1, 2=>1])
+    end
+
+    majumps   = MassActionJump(rates, reactstoch, netstoch)
+    jset      = JumpSet((), (), nothing, majumps)
+    prob      = DiscreteProblem([A0,0], (0.0,tf))
+    jump_prob = JumpProblem(prob, method, jset; save_positions=(false,false))
+
+    jump_prob
+end
+
+# uses a mass action jump to represent half the reactions and a vector of constant jumps for the other half
+# stores them in a JumpSet
+function A_to_B_mean_hybrid(N, method)
+    # half reactions are treated as mass action and half as constant jumps
+    switchidx = (N//2).num
+
+    # mass action reactions
+    reactstoch = Vector{Vector{Pair{Int64,Int64}}}();
+    netstoch   = Vector{Vector{Pair{Int64,Int64}}}();
+    for i in 1:switchidx
+        push!(reactstoch,[1 => 1])
+        push!(netstoch,[1 => -1, 2=>1])
+    end
+
+     # jump reactions
+     jumps = Vector{ConstantRateJump}()
+     for i in (switchidx+1):N
+         ratefunc = (u,p,t) -> rates[i] * u[1]
+         affect!  = function (integrator)
+             integrator.u[1] -= 1
+             integrator.u[2] += 1
+         end
+         push!(jumps, ConstantRateJump(ratefunc, affect!))
+     end
+
+    majumps   = MassActionJump(rates[1:switchidx] , reactstoch, netstoch)
+    jset      = JumpSet((), jumps, nothing, majumps)
+    prob      = DiscreteProblem([A0,0], (0.0,tf))
+    jump_prob = JumpProblem(prob, method, jset; save_positions=(false,false))
+
+    jump_prob
+end
+
+# uses a mass action jump to represent half the reactions and a vector of constant jumps for the other half
+# passes them to JumpProblem as a splatted tuple
+function A_to_B_mean_hybrid_nojset(N, method)
+    # half reactions are treated as mass action and half as constant jumps
+    switchidx = (N//2).num
+
+    # mass action reactions
+    reactstoch = Vector{Vector{Pair{Int64,Int64}}}();
+    netstoch   = Vector{Vector{Pair{Int64,Int64}}}();
+    for i in 1:switchidx
+        push!(reactstoch,[1 => 1])
+        push!(netstoch,[1 => -1, 2=>1])
+    end
+
+     # jump reactions
+     jumpvec = Vector{ConstantRateJump}()
+     for i in (switchidx+1):N
+         ratefunc = (u,p,t) -> rates[i] * u[1]
+         affect!  = function (integrator)
+             integrator.u[1] -= 1
+             integrator.u[2] += 1
+         end
+         push!(jumpvec, ConstantRateJump(ratefunc, affect!))
+     end
+    constjumps = (jump for jump in jumpvec)
+    majumps   = MassActionJump(rates[1:switchidx] , reactstoch, netstoch)
+    jumps     = (constjumps...,majumps)
+    prob      = DiscreteProblem([A0,0], (0.0,tf))
+    jump_prob = JumpProblem(prob, method, jumps...; save_positions=(false,false))
+
+    jump_prob
+end
+
+means = []
+
+method = Direct()
+
+# tuples
+jump_prob_orig = A_to_B_mean_orig(Nrxs, method)
+push!(means, runSSAs(jump_prob_orig))
+
+# hybrid of tuples and mass action
+jump_prob_hybrid_orig = A_to_B_mean_hybrid(Nrxs, method)
+push!(means, runSSAs(jump_prob_hybrid_orig))
+
+# hybrid of tuples and mass action (no JumpSet)
+jump_prob_hybrid_orig_nojset = A_to_B_mean_hybrid(Nrxs, method)
+push!(means, runSSAs(jump_prob_hybrid_orig_nojset))
+
+method = DirectManyJumps()
+
+# function wrappers
+jump_prob_fw = A_to_B_mean(Nrxs, method)
+push!(means, runSSAs(jump_prob_fw))
+
+# mass action
+jump_prob_ma = A_to_B_mean_ma(Nrxs, method)
+push!(means, runSSAs(jump_prob_ma))
+
+# hybrid
+jump_prob_hybrid = A_to_B_mean_hybrid(Nrxs, method)
+push!(means, runSSAs(jump_prob_hybrid))
+
+# hybrid with jumps passed individually to JumpProblem (no JumpSet)
+jump_prob_hybrid_nojset = A_to_B_mean_hybrid_nojset(Nrxs, method)
+push!(means, runSSAs(jump_prob_hybrid_nojset))
+
+exactmeanval = exactmean(tf, rates)
+for meanval in means
+    if doprint
+        println("samp mean: ", meanval, ", act mean = ", exactmeanval)
+    end
+
+    if dotest
+        @test abs(meanval - exactmeanval) < 1.
+    end
+end
+
+# if dobenchmark
+#     @btime runSSAs($jump_prob_orig)
+#     @btime runSSAs($jump_prob_hybrid_orig)
+#     @btime runSSAs($jump_prob_fw)
+#     @btime runSSAs($jump_prob_ma)
+#     @btime runSSAs($jump_prob_hybrid)
+# end
+

--- a/test/linearreaction_test.jl
+++ b/test/linearreaction_test.jl
@@ -18,7 +18,7 @@ rates = ones(Float64, Nrxs) * baserate;
 cumsum!(rates, rates)    
 
 function runSSAs(jump_prob)
-    Asamp = zeros(Int64,Nsims)
+    Asamp = zeros(Int,Nsims)
     for i in 1:Nsims
         sol = solve(jump_prob, SSAStepper())
         Asamp[i] = sol[1,end]
@@ -71,8 +71,8 @@ end
 
 # uses a mass action jump to represent all reactions
 function A_to_B_mean_ma(N, method)
-    reactstoch = Vector{Vector{Pair{Int64,Int64}}}();
-    netstoch   = Vector{Vector{Pair{Int64,Int64}}}();
+    reactstoch = Vector{Vector{Pair{Int,Int}}}();
+    netstoch   = Vector{Vector{Pair{Int,Int}}}();
     for i = 1:N
         push!(reactstoch,[1 => 1])
         push!(netstoch,[1 => -1, 2=>1])
@@ -93,8 +93,8 @@ function A_to_B_mean_hybrid(N, method)
     switchidx = (N//2).num
 
     # mass action reactions
-    reactstoch = Vector{Vector{Pair{Int64,Int64}}}();
-    netstoch   = Vector{Vector{Pair{Int64,Int64}}}();
+    reactstoch = Vector{Vector{Pair{Int,Int}}}();
+    netstoch   = Vector{Vector{Pair{Int,Int}}}();
     for i in 1:switchidx
         push!(reactstoch,[1 => 1])
         push!(netstoch,[1 => -1, 2=>1])
@@ -126,8 +126,8 @@ function A_to_B_mean_hybrid_nojset(N, method)
     switchidx = (N//2).num
 
     # mass action reactions
-    reactstoch = Vector{Vector{Pair{Int64,Int64}}}();
-    netstoch   = Vector{Vector{Pair{Int64,Int64}}}();
+    reactstoch = Vector{Vector{Pair{Int,Int}}}();
+    netstoch   = Vector{Vector{Pair{Int,Int}}}();
     for i in 1:switchidx
         push!(reactstoch,[1 => 1])
         push!(netstoch,[1 => -1, 2=>1])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,4 +6,5 @@ tic()
 @time @testset "Split Coupled Tests" begin include("splitcoupled.jl") end
 @time @testset "SSA Tests" begin include("ssa_tests.jl") end
 @time @testset "Tau Leaping Tests" begin include("regular_jumps.jl") end
+@time @testset "Mass Action Jump Tests" begin include("linearreaction_test.jl") end
 toc()


### PR DESCRIPTION
OK, here is a first try adding in a new `MassActionJump`. I've also added a new test script that verifies for a linear reaction system that the SSAs get the right mean using each of
1. tuple-based constant jumps
2. function wrapper-based constant jumps
3. a mass action jump
4. a hybrid of tuples and mass action 
5. a hybrid of function wrappers and mass action

Once this is fixed up and approved I'll work on a couple more test scripts with nonlinear reactions. It would be good to have a database of a few examples before starting on new SSAs algorithms.

EDIT: I called the new function wrapper aggregator algorithm `DirectManyJumps`. I'm happy to change that if someone has a better name...