### PR TITLE
Optimized SSA support and FRM

### DIFF
--- a/src/DiffEqJump.jl
+++ b/src/DiffEqJump.jl
@@ -18,6 +18,7 @@ include("massaction_rates.jl")
 include("aggregators/aggregators.jl")
 include("aggregators/ssajump.jl")
 include("aggregators/direct.jl")
+include("aggregators/frm.jl")
 include("jumps.jl")
 include("problem.jl")
 include("callbacks.jl")
@@ -29,7 +30,8 @@ include("SSA_stepper.jl")
 include("simple_regular_solve.jl")
 include("juno_rendering.jl")
 
-export AbstractJump, AbstractAggregatorAlgorithm, AbstractJumpAggregator, AbstractJumpProblem
+export AbstractJump, AbstractAggregatorAlgorithm, AbstractJumpAggregator, 
+       AbstractSSAJumpAggregator, AbstractJumpProblem
 
 export ConstantRateJump, VariableRateJump, RegularJump, MassActionJump, 
        JumpSet, CompoundConstantRateJump
@@ -38,7 +40,7 @@ export JumpProblem
 
 export SplitCoupledJumpProblem
 
-export Direct, DirectManyJumps
+export Direct, DirectFW, FRM, FRMFW
 
 export init, solve, solve!
 

--- a/src/aggregators/aggregators.jl
+++ b/src/aggregators/aggregators.jl
@@ -1,5 +1,7 @@
 struct Direct <: AbstractAggregatorAlgorithm end
-struct DirectManyJumps <: AbstractAggregatorAlgorithm end 
+struct DirectFW <: AbstractAggregatorAlgorithm end 
+struct FRM <: AbstractAggregatorAlgorithm end
+struct FRMFW <: AbstractAggregatorAlgorithm end
 
 # For JumpProblem construction without an aggregator
 struct NullAggregator <: AbstractAggregatorAlgorithm end

--- a/src/aggregators/frm.jl
+++ b/src/aggregators/frm.jl
@@ -1,0 +1,151 @@
+mutable struct FRMJumpAggregation{T,S,F1,F2,RNG} <: AbstractSSAJumpAggregator
+  next_jump::Int
+  next_jump_time::T
+  end_time::T
+  cur_rates::Vector{T}
+  sum_rate::T
+  ma_jumps::S
+  rates::F1
+  affects!::F2
+  save_positions::Tuple{Bool,Bool}
+  rng::RNG
+end
+FRMJumpAggregation(nj, njt, et, crs, sr, maj, rs, affs!, sps, rng; kwargs...) = FRMJumpAggregation(nj, njt, et, crs, sr, maj, rs, affs!, sps, rng)
+
+
+########### The following routines should be templates for all SSAs ###########
+
+# condition for jump to occur
+@inline function (p::FRMJumpAggregation)(u, t, integrator) 
+  p.next_jump_time == t
+end
+
+# executing jump at the next jump time
+function (p::FRMJumpAggregation)(integrator) 
+  execute_jumps!(p, integrator, integrator.u, integrator.p, integrator.t)
+  generate_jumps!(p, integrator, integrator.u, integrator.p, integrator.t)
+  register_next_jump_time!(integrator, p, integrator.t)
+  nothing
+end
+
+# setting up a new simulation
+function (p::FRMJumpAggregation)(dj, u, t, integrator) # initialize
+  initialize!(p, integrator, u, integrator.p, t)
+  register_next_jump_time!(integrator, p, t)
+  nothing
+end
+
+############################# Required Functions #############################
+
+# creating the JumpAggregation structure (tuple-based constant jumps)
+function aggregate(aggregator::FRM, u, p, t, end_time, constant_jumps, 
+                    ma_jumps, save_positions, rng; kwargs...)
+
+  # handle constant jumps using tuples
+  rates, affects! = get_jump_info_tuples(constant_jumps)
+
+  build_jump_aggregation(FRMJumpAggregation, u, p, t, end_time, ma_jumps, rates, affects!, 
+                          save_positions, rng; kwargs...)
+end
+
+# creating the JumpAggregation structure (function wrapper-based constant jumps)
+function aggregate(aggregator::FRMFW, u, p, t, end_time, constant_jumps, 
+                    ma_jumps, save_positions, rng; kwargs...)
+
+  # handle constant jumps using function wrappers
+  rates, affects! = get_jump_info_fwrappers(u, p, t, constant_jumps)
+
+  build_jump_aggregation(FRMJumpAggregation, u, p, t, end_time, ma_jumps, rates, affects!, 
+                          save_positions, rng; kwargs...)
+end
+
+# set up a new simulation and calculate the first jump / jump time
+function initialize!(p::FRMJumpAggregation, integrator, u, params, t)    
+  generate_jumps!(p, integrator, u, params, t)
+  nothing
+end
+
+# execute one jump, changing the system state
+@inline function execute_jumps!(p::FRMJumpAggregation, integrator, u, params, t)
+  num_ma_rates = length(p.ma_jumps.scaled_rates)
+  if p.next_jump <= num_ma_rates
+      @inbounds executerx!(u, p.ma_jumps.net_stoch[p.next_jump])
+  else
+      idx = p.next_jump - num_ma_rates
+      @inbounds p.affects![idx](integrator)
+  end
+  nothing
+end
+
+# calculate the next jump / jump time
+function generate_jumps!(p::FRMJumpAggregation, integrator, u, params, t)
+  nextmaj, ttnmaj = next_ma_jump(p, u, params, t)
+  nextcrj, ttncrj = next_constant_rate_jump(p, u, params, t)
+
+  # execute reaction with minimal time
+  if ttnmaj < ttncrj
+    p.next_jump      = nextmaj
+    p.next_jump_time = t + ttnmaj
+  else
+    p.next_jump      = nextcrj
+    p.next_jump_time = t + ttncrj
+  end
+  nothing
+end
+
+
+######################## SSA specific helper routines ########################
+
+# mass action jumps
+@fastmath function next_ma_jump(p::FRMJumpAggregation, u, params, t)
+    ttnj      = typemax(typeof(t))    
+    nextrx    = zero(Int)
+    majumps   = p.ma_jumps
+    @inbounds for i in eachindex(majumps.scaled_rates)
+        p.cur_rates[i] = evalrxrate(u, majumps.scaled_rates[i], majumps.reactant_stoch[i])
+        dt = randexp(p.rng) / p.cur_rates[i]
+        if dt < ttnj
+            ttnj   = dt
+            nextrx = i
+        end    
+    end
+    nextrx, ttnj
+end
+
+# tuple-based constant jumps
+@fastmath function next_constant_rate_jump(p::FRMJumpAggregation{T,S,F1,F2,RNG}, u, params, t) where {T,S,F1 <: Tuple, F2 <: Tuple, RNG}
+    ttnj   = typemax(typeof(t))
+    nextrx = zero(Int)
+    if !isempty(p.rates)
+        idx = length(p.ma_jumps.scaled_rates) + 1
+        fill_cur_rates(u, params, t, p.cur_rates, idx, p.rates...)
+        @inbounds for i in idx:length(p.cur_rates)
+            dt = randexp(p.rng) / p.cur_rates[i]
+            if dt < ttnj
+                ttnj   = dt
+                nextrx = i
+            end
+        end
+    end
+    nextrx, ttnj
+end
+
+# function wrapper-based constant jumps
+@fastmath function next_constant_rate_jump(p::FRMJumpAggregation{T,S,F1,F2,RNG}, u, params, t) where {T,S,F1 <: AbstractArray,F2 <: AbstractArray, RNG}
+    ttnj   = typemax(typeof(t))
+    nextrx = zero(Int)
+    if !isempty(p.rates)
+        idx = length(p.ma_jumps.scaled_rates) + 1  
+        @inbounds for i in 1:length(p.rates)
+            p.cur_rates[idx] = p.rates[i](u, params, t)
+            dt = randexp(p.rng) / p.cur_rates[idx]
+            if dt < ttnj
+                ttnj   = dt
+                nextrx = idx
+            end
+            idx += 1
+        end
+    end    
+    nextrx, ttnj
+end
+

--- a/src/aggregators/ssajump.jl
+++ b/src/aggregators/ssajump.jl
@@ -46,4 +46,28 @@ abstract type AbstractSSAJumpAggregator <: AbstractJumpAggregator end
   nothing
 end
 
+# helper routine for setting up standard fields of SSA jump aggregations
+function build_jump_aggregation(jump_agg_type, u, p, t, end_time, ma_jumps, rates, 
+                                affects!, save_positions, rng; kwargs...)
+
+  # mass action jumps
+  majumps = ma_jumps
+  if majumps == nothing
+    majumps = MassActionJump(Vector{typeof(t)}(),
+                             Vector{Vector{Pair{Int,eltype(u)}}}(),
+                             Vector{Vector{Pair{Int,eltype(u)}}}() )
+  end
+
+  # current jump rates, allows mass action rates and constant jumps
+  cur_rates = Vector{typeof(t)}(length(majumps.scaled_rates) + length(rates))
+
+  sum_rate = zero(typeof(t))
+  next_jump = 0
+  next_jump_time = typemax(typeof(t))
+  jump_agg_type(next_jump, next_jump_time, end_time, cur_rates, sum_rate, 
+                majumps, rates, affects!, save_positions, rng; kwargs...)
+end
+
 DiscreteCallback(c::AbstractSSAJumpAggregator) =DiscreteCallback(c, c, initialize = c, save_positions = c.save_positions)
+
+

--- a/src/problem.jl
+++ b/src/problem.jl
@@ -23,7 +23,7 @@ JumpProblem(prob,jumps::JumpSet;kwargs...) = JumpProblem(prob,NullAggregator(),j
 
 function JumpProblem(prob, aggregator::AbstractAggregatorAlgorithm, jumps::JumpSet;
                      save_positions = typeof(prob) <: AbstractDiscreteProblem ? (false,true) : (true,true),
-                     rng = Xorshifts.Xoroshiro128Star(rand(UInt64)))
+                     rng = Xorshifts.Xoroshiro128Star(rand(UInt64)), kwargs...)
 
   ## Constant Rate Handling
   t,end_time,u = prob.tspan[1],prob.tspan[2],prob.u0
@@ -31,7 +31,7 @@ function JumpProblem(prob, aggregator::AbstractAggregatorAlgorithm, jumps::JumpS
     disc = nothing
     constant_jump_callback = CallbackSet()
   else    
-    disc = aggregate(aggregator,u,prob.p,t,end_time,jumps.constant_jumps,jumps.massaction_jump,save_positions,rng)    
+    disc = aggregate(aggregator,u,prob.p,t,end_time,jumps.constant_jumps,jumps.massaction_jump,save_positions,rng;kwargs...)    
     constant_jump_callback = DiscreteCallback(disc)
   end
 

--- a/test/linearreaction_test.jl
+++ b/test/linearreaction_test.jl
@@ -5,7 +5,7 @@ using Base.Test
 # using BenchmarkTools
 # dobenchmark = true
 
-doprint     = true
+doprint     = false
 dotest      = true
 Nrxs        = 16
 Nsims       = 8000


### PR DESCRIPTION
1. To enable more general SSA support, kwargs are passed down from `JumpProblem` into `aggregate`. Along with this I made `build_jump_aggregation` a generic routine that should handle setting up all the required universal SSA fields. A `JumpAggregation` outer constructor then accepts kwargs and can use them to require additional SSA specific information (like dependency graphs). This should allow users to make their own SSAs / `JumpAggregations`, possibly requiring additional info, outside of `DiffEqJump` and still have them work through `JumpProblem`.
2. Added first reaction method implementations (FRM and FRMFW). 
3. Renamed `DirectManyJumps` to `DirectFW`.