### PR TITLE
updating JumpAggregation constructors, adding MassActionJump nonlinear rx tests

### DIFF
--- a/src/aggregators/direct.jl
+++ b/src/aggregators/direct.jl
@@ -9,8 +9,11 @@ mutable struct DirectJumpAggregation{T,S,F1,F2,RNG} <: AbstractSSAJumpAggregator
   affects!::F2
   save_positions::Tuple{Bool,Bool}
   rng::RNG
+  DirectJumpAggregation{T,S,F1,F2,RNG}(nj::Int, njt::T, et::T, crs::Vector{T}, sr::T, maj::S, rs::F1, affs!::F2, sps::Tuple{Bool,Bool}, rng::RNG) where {T,S,F1,F2,RNG} = 
+    new{T,S,F1,F2,RNG}(nj, njt, et, crs, sr, maj, rs, affs!, sps, rng)
 end
-DirectJumpAggregation(nj, njt, et, crs, sr, maj, rs, affs!, sps, rng; kwargs...) = DirectJumpAggregation(nj, njt, et, crs, sr, maj, rs, affs!, sps, rng)
+DirectJumpAggregation(nj::Int, njt::T, et::T, crs::Vector{T}, sr::T, maj::S, rs::F1, affs!::F2, sps::Tuple{Bool,Bool}, rng::RNG; kwargs...) where {T,S,F1,F2,RNG} = 
+  DirectJumpAggregation{T,S,F1,F2,RNG}(nj, njt, et, crs, sr, maj, rs, affs!, sps, rng)
 
 
 ########### The following routines should be templates for all SSAs ###########

--- a/src/aggregators/frm.jl
+++ b/src/aggregators/frm.jl
@@ -9,8 +9,11 @@ mutable struct FRMJumpAggregation{T,S,F1,F2,RNG} <: AbstractSSAJumpAggregator
   affects!::F2
   save_positions::Tuple{Bool,Bool}
   rng::RNG
+  FRMJumpAggregation{T,S,F1,F2,RNG}(nj::Int, njt::T, et::T, crs::Vector{T}, sr::T, maj::S, rs::F1, affs!::F2, sps::Tuple{Bool,Bool}, rng::RNG) where {T,S,F1,F2,RNG} = 
+    new{T,S,F1,F2,RNG}(nj, njt, et, crs, sr, maj, rs, affs!, sps, rng)
 end
-FRMJumpAggregation(nj, njt, et, crs, sr, maj, rs, affs!, sps, rng; kwargs...) = FRMJumpAggregation(nj, njt, et, crs, sr, maj, rs, affs!, sps, rng)
+FRMJumpAggregation(nj::Int, njt::T, et::T, crs::Vector{T}, sr::T, maj::S, rs::F1, affs!::F2, sps::Tuple{Bool,Bool}, rng::RNG; kwargs...) where {T,S,F1,F2,RNG} = 
+    FRMJumpAggregation{T,S,F1,F2,RNG}(nj, njt, et, crs, sr, maj, rs, affs!, sps, rng)
 
 
 ########### The following routines should be templates for all SSAs ###########

--- a/src/problem.jl
+++ b/src/problem.jl
@@ -157,6 +157,6 @@ function Base.show(io::IO, A::JumpProblem)
     println(io,"Have a regular jump")
   end
   if (A.massaction_jump != nothing) && !isempty(A.massaction_jump.scaled_rates) 
-    println(i0,"Have a mass action jump")
+    println(io,"Have a mass action jump")
   end
 end

--- a/test/bimolerx_test.jl
+++ b/test/bimolerx_test.jl
@@ -21,7 +21,6 @@ reltol       = .01
 
 # MODEL SETUP
 
-# DNA repression model DiffEqBiological
 # using DiffEqBiological
 # rs = @reaction_network dtype begin
 #     k1, 2A --> B

--- a/test/bimolerx_test.jl
+++ b/test/bimolerx_test.jl
@@ -1,0 +1,109 @@
+using DiffEqBase, DiffEqJump
+using Base.Test
+
+# using Plots; plotlyjs()
+doplot = false
+
+# using BenchmarkTools
+# dobenchmark = false
+
+dotestmean   = true
+doprintmeans = false
+
+# SSAs to test
+SSAalgs = (Direct(),FRM()) #,DirectFW(), FRM(), FRMFW())
+
+Nsims        = 32000
+tf           = .01
+u0           = [200, 100, 150]
+expected_avg = 84.876015624999994
+reltol       = .01
+
+# MODEL SETUP
+
+# DNA repression model DiffEqBiological
+# using DiffEqBiological
+# rs = @reaction_network dtype begin
+#     k1, 2A --> B
+#     k2, B --> 2A 
+#     k3, A + B --> C
+#     k4, C --> A + B
+#     k5, 3C --> 3A
+# end k1 k2 k3 k4 
+
+# model using mass action jumps
+# ids: A = 1, B = 2, C = 3
+reactstoch = 
+[ 
+    [1 => 2],
+    [2 => 1],
+    [1 => 1, 2 => 1],
+    [3 => 1],
+    [3 => 3]
+]
+netstoch = 
+[ 
+    [1 => -2, 2 => 1],
+    [1 => 2, 2 => -1],
+    [1 => -1, 2 => -1, 3 => 1],
+    [1 => 1, 2 => 1, 3 => -1],
+    [1 => 3, 3 => -3]
+]
+rates = [1., 2., .5, .75, .25]
+majumps = MassActionJump(rates, reactstoch, netstoch)
+
+# average number of proteins in a simulation
+function runSSAs(jump_prob)
+    Psamp = zeros(Int, Nsims)
+    for i in 1:Nsims
+        sol = solve(jump_prob, SSAStepper())
+        Psamp[i] = sol[1,end]
+    end
+    mean(Psamp)
+end
+
+# TESTING:
+prob = DiscreteProblem(u0, (0.0, tf), rates)
+
+# plotting one full trajectory
+if doplot
+    for alg in SSAalgs
+        jump_prob = JumpProblem(prob, alg, majumps)
+        sol = solve(jump_prob, SSAStepper())
+        plothand = plot(sol, seriestype=:steppost, reuse=false)
+        display(plothand)
+    end
+end
+
+# test the means
+if dotestmean
+    means = zeros(Float64,length(SSAalgs))
+    for (i,alg) in enumerate(SSAalgs)
+        jump_prob = JumpProblem(prob, alg, majumps, save_positions=(false,false))
+        means[i]  = runSSAs(jump_prob)
+        relerr = abs(means[i] - expected_avg) / expected_avg
+        if doprintmeans
+            println("Mean from method: ", typeof(alg), " is = ", means[i], ", rel err = ", relerr)
+        end
+
+        # if dobenchmark
+        #      @btime (runSSAs($jump_prob);)
+        # end
+
+
+        @test abs(means[i] - expected_avg) < reltol*expected_avg
+    end
+end
+
+
+# benchmark performance
+# if dobenchmark
+#     # exact methods
+#     for alg in SSAalgs
+#         println("Solving with method: ", typeof(alg), ", using SSAStepper")
+#         jump_prob = JumpProblem(prob, alg, majumps)
+#         @btime solve($jump_prob, SSAStepper())
+#     end
+#     println()
+# end
+

--- a/test/geneexpr_test.jl
+++ b/test/geneexpr_test.jl
@@ -1,0 +1,113 @@
+using DiffEqBase, DiffEqJump
+using Base.Test
+
+# using Plots; plotlyjs()
+doplot = false
+# using BenchmarkTools
+# dobenchmark = false
+
+dotestmean   = true
+doprintmeans = false
+
+# SSAs to test
+SSAalgs = (Direct(),) #, DirectFW(), FRM(), FRMFW())
+
+Nsims        = 8000
+tf           = 1000.0
+u0           = [1,0,0,0]
+expected_avg = 5.926553750000000e+02
+reltol       = .01
+
+# average number of proteins in a simulation
+function runSSAs(jump_prob)
+    Psamp = zeros(Int, Nsims)
+    for i in 1:Nsims
+        sol = solve(jump_prob, SSAStepper())
+        Psamp[i] = sol[3,end]
+    end
+    mean(Psamp)
+end
+
+# MODEL SETUP
+
+# DNA repression model DiffEqBiological
+# using DiffEqBiological
+# rs = @reaction_network dtype begin
+#     k1, DNA --> mRNA + DNA
+#     k2, mRNA --> mRNA + P
+#     k3, mRNA --> 0
+#     k4, P --> 0
+#     k5, DNA + P --> DNAR
+#     k6, DNAR --> DNA + P
+# end k1 k2 k3 k4 k5 k6
+
+# model using mass action jumps
+# ids: DNA=1, mRNA = 2, P = 3, DNAR = 4
+reactstoch = 
+[ 
+    [1 => 1],
+    [2 => 1],
+    [2 => 1],
+    [3 => 1],
+    [1 => 1, 3 => 1],
+    [4 => 1] 
+]
+netstoch = 
+[ 
+    [2 => 1],
+    [3 => 1],
+    [2 => -1],
+    [3 => -1],
+    [1 => -1, 3 => -1, 4 => 1],
+    [1 => 1, 3 => 1, 4 => -1] 
+]
+rates = [.5, (20*log(2.)/120.), (log(2.)/120.), (log(2.)/600.), .025, 1.]
+majumps = MassActionJump(rates, reactstoch, netstoch)
+
+
+# TESTING:
+prob = DiscreteProblem(u0, (0.0, tf), rates)
+
+# plotting one full trajectory
+if doplot
+    plothand = plot(reuse=false)
+    for alg in SSAalgs
+        jump_prob = JumpProblem(prob, alg, majumps)
+        sol = solve(jump_prob, SSAStepper())
+        plot!(plothand, sol.t, sol[3,:], seriestype=:steppost)
+    end
+    display(plothand)
+end
+
+# test the means
+if dotestmean
+    means = zeros(Float64,length(SSAalgs))
+    for (i,alg) in enumerate(SSAalgs)
+        jump_prob = JumpProblem(prob, alg, majumps, save_positions=(false,false))
+        means[i]  = runSSAs(jump_prob)
+        relerr = abs(means[i] - expected_avg) / expected_avg
+        if doprintmeans
+            println("Mean from method: ", typeof(alg), " is = ", means[i], ", rel err = ", relerr)
+        end
+
+        # if dobenchmark
+        #     @btime (runSSAs($jump_prob);)
+        # end
+
+
+        @test abs(means[i] - expected_avg) < reltol*expected_avg
+    end
+end
+
+
+# benchmark performance
+# if dobenchmark
+#     # exact methods
+#     for alg in SSAalgs
+#         println("Solving with method: ", typeof(alg), ", using SSAStepper")
+#         jump_prob = JumpProblem(prob, alg, majumps)
+#         @btime solve($jump_prob, SSAStepper())
+#     end
+#     println()
+# end
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,5 +6,7 @@ tic()
 @time @testset "Split Coupled Tests" begin include("splitcoupled.jl") end
 @time @testset "SSA Tests" begin include("ssa_tests.jl") end
 @time @testset "Tau Leaping Tests" begin include("regular_jumps.jl") end
-@time @testset "Mass Action Jump Tests" begin include("linearreaction_test.jl") end
+@time @testset "Linear Reaction SSA Test" begin include("linearreaction_test.jl") end
+@time @testset "Mass Action Jump Tests; Gene Expr Model" begin include("geneexpr_test.jl") end
+@time @testset "Mass Action Jump Tests; Nonlinear Rx Model" begin include("bimolerx_test.jl") end
 toc()


### PR DESCRIPTION
1. Allow kwargs to be sent to the JumpAggregation constructor. Right now it isn't used, but future SSAs could require options to be passed down in this way. Code coverage showed the previous commit's version of the outer constructor wasn't actually being called.
2. Added two tests, a small gene expression network and a system with a mix of bimolecular and trimolecular reactions, to test `MassActionJumps`.
