### PR TITLE
Fix scaling rates twice when merging MassActionJumps

### DIFF
--- a/src/jumps.jl
+++ b/src/jumps.jl
@@ -65,7 +65,7 @@ struct MassActionJump{T,S} <: AbstractJump
   end
 
 end
-MassActionJump(usr::T, rs::S, ns::S; scale_rates = true ) where {T,S} = MassActionJump{T,S}(usr, rs, ns, scale_rates)
+MassActionJump(usr::T, rs::S, ns::S; scale_rates = true) where {T,S} = MassActionJump{T,S}(usr, rs, ns, scale_rates)
 
 struct JumpSet{T1,T2,T3,T4} <: AbstractJump
   variable_jumps::T1
@@ -121,12 +121,12 @@ check_majump_type(maj::MassActionJump{S,T}) where {S <: Number, T} = setup_majum
 
 # if given containers of rates and stoichiometry directly create a jump
 function setup_majump_to_merge(sr::T, rs::AbstractVector{S}, ns::AbstractVector{S}) where {T <: AbstractVector, S <: AbstractArray}
-  MassActionJump(sr, rs, ns)
+  MassActionJump(sr, rs, ns; scale_rates=false)
 end
 
 # if just given the data for one jump (and not in a container) wrap in a vector
 function setup_majump_to_merge(sr::T, rs::S, ns::S) where {T <: Number, S <: AbstractArray}
-  MassActionJump([sr], [rs], [ns])
+  MassActionJump([sr], [rs], [ns]; scale_rates=false)
 end
 
 # when given a collection of reactions to add to maj
@@ -148,7 +148,7 @@ end
 # when maj only stores a single jump's worth of data (and not in a collection)
 # create a new jump with the merged data stored in vectors
 function majump_merge!(maj::MassActionJump{T,S}, sr::T, rs::S, ns::S) where {T <: Number, S <: AbstractArray}
-  MassActionJump([maj.scaled_rates, sr], [maj.reactant_stoch, rs], [maj.net_stoch, ns])
+  MassActionJump([maj.scaled_rates, sr], [maj.reactant_stoch, rs], [maj.net_stoch, ns]; scale_rates=false)
 end
 
 massaction_jump_combine(maj1::MassActionJump, maj2::Void) = maj1

--- a/test/bimolerx_test.jl
+++ b/test/bimolerx_test.jl
@@ -106,3 +106,20 @@ end
 #     println()
 # end
 
+
+
+# add a test for passing MassActionJumps individually (tests combining)
+if dotestmean
+    majump_vec = Vector{MassActionJump{Float64,Vector{Pair{Int,Int}}}}()
+    for i = 1:length(rates)
+        push!(majump_vec, MassActionJump(rates[i], reactstoch[i], netstoch[i]))
+    end
+    jset = JumpSet((),(),nothing,majump_vec)
+    jump_prob = JumpProblem(prob, Direct(), jset, save_positions=(false,false))
+    meanval = runSSAs(jump_prob)
+    relerr = abs(meanval - expected_avg) / expected_avg
+    if doprintmeans
+        println("Using individual MassActionJumps; Mean from method: ", typeof(Direct()), " is = ", meanval, ", rel err = ", relerr)
+    end
+    @test abs(meanval - expected_avg) < reltol*expected_avg
+end

--- a/test/degenerate_rx_cases.jl
+++ b/test/degenerate_rx_cases.jl
@@ -90,7 +90,7 @@ if doplot
 end
 
 for method in methods
-    jump_prob = JumpProblem(prob, Direct(), jump, jump2)
+    jump_prob = JumpProblem(prob, method, jump, jump2)
     sol = solve(jump_prob, SSAStepper())
     
     if doplot        


### PR DESCRIPTION
- The `MassActionJump` merging methods need to pass `scale_rates=false`, otherwise nonlinear reaction rates get rescaled more than once when merging occurs.
- Added test to catch related bugs in the future. Updated one test that was meant to be called on all the SSAs, but was only being called on `Direct`.