### PR TITLE
Cleanup MassActionJump reaction rate function interface

### DIFF
--- a/src/DiffEqJump.jl
+++ b/src/DiffEqJump.jl
@@ -14,12 +14,12 @@ import RecursiveArrayTools: recursivecopy!
 @compat abstract type AbstractJumpAggregator end
 @compat abstract type AbstractJumpProblem{P,J} <: DEProblem end
 
+include("jumps.jl")
 include("massaction_rates.jl")
 include("aggregators/aggregators.jl")
 include("aggregators/ssajump.jl")
 include("aggregators/direct.jl")
 include("aggregators/frm.jl")
-include("jumps.jl")
 include("problem.jl")
 include("callbacks.jl")
 include("solve.jl")

--- a/src/aggregators/direct.jl
+++ b/src/aggregators/direct.jl
@@ -70,7 +70,7 @@ end
 
 # execute one jump, changing the system state
 @inline function execute_jumps!(p::DirectJumpAggregation, integrator, u, params, t)
-  num_ma_rates = length(p.ma_jumps.scaled_rates)
+  num_ma_rates = get_num_majumps(p.ma_jumps)
   if p.next_jump <= num_ma_rates
       @inbounds executerx!(u, p.next_jump, p.ma_jumps) 
   else
@@ -99,7 +99,7 @@ end
 
   # mass action rates
   majumps   = p.ma_jumps
-  idx       = length(majumps.scaled_rates)
+  idx       = get_num_majumps(majumps)
   @inbounds for i in 1:idx
     new_rate     = evalrxrate(u, i, majumps) 
     cur_rates[i] = new_rate + prev_rate
@@ -141,7 +141,7 @@ end
 
   # mass action rates
   majumps   = p.ma_jumps
-  idx       = length(majumps.scaled_rates)
+  idx       = get_num_majumps(majumps)
   @inbounds for i in 1:idx
     new_rate     = evalrxrate(u, i, majumps) 
     cur_rates[i] = new_rate + prev_rate

--- a/src/aggregators/direct.jl
+++ b/src/aggregators/direct.jl
@@ -72,7 +72,7 @@ end
 @inline function execute_jumps!(p::DirectJumpAggregation, integrator, u, params, t)
   num_ma_rates = length(p.ma_jumps.scaled_rates)
   if p.next_jump <= num_ma_rates
-      @inbounds executerx!(u, p.ma_jumps.net_stoch[p.next_jump])
+      @inbounds executerx!(u, p.next_jump, p.ma_jumps) 
   else
       idx = p.next_jump - num_ma_rates
       @inbounds p.affects![idx](integrator)
@@ -101,7 +101,7 @@ end
   majumps   = p.ma_jumps
   idx       = length(majumps.scaled_rates)
   @inbounds for i in 1:idx
-    new_rate     = evalrxrate(u, majumps.scaled_rates[i], majumps.reactant_stoch[i])
+    new_rate     = evalrxrate(u, i, majumps) 
     cur_rates[i] = new_rate + prev_rate
     prev_rate    = cur_rates[i]
   end
@@ -143,7 +143,7 @@ end
   majumps   = p.ma_jumps
   idx       = length(majumps.scaled_rates)
   @inbounds for i in 1:idx
-    new_rate     = evalrxrate(u, majumps.scaled_rates[i], majumps.reactant_stoch[i])
+    new_rate     = evalrxrate(u, i, majumps) 
     cur_rates[i] = new_rate + prev_rate
     prev_rate    = cur_rates[i]
   end

--- a/src/aggregators/frm.jl
+++ b/src/aggregators/frm.jl
@@ -72,7 +72,7 @@ end
 @inline function execute_jumps!(p::FRMJumpAggregation, integrator, u, params, t)
   num_ma_rates = length(p.ma_jumps.scaled_rates)
   if p.next_jump <= num_ma_rates
-      @inbounds executerx!(u, p.ma_jumps.net_stoch[p.next_jump])
+      @inbounds executerx!(u, p.next_jump, p.ma_jumps) 
   else
       idx = p.next_jump - num_ma_rates
       @inbounds p.affects![idx](integrator)
@@ -105,7 +105,7 @@ end
     nextrx    = zero(Int)
     majumps   = p.ma_jumps
     @inbounds for i in eachindex(majumps.scaled_rates)
-        p.cur_rates[i] = evalrxrate(u, majumps.scaled_rates[i], majumps.reactant_stoch[i])
+        p.cur_rates[i] = evalrxrate(u, i, majumps) 
         dt = randexp(p.rng) / p.cur_rates[i]
         if dt < ttnj
             ttnj   = dt

--- a/src/aggregators/frm.jl
+++ b/src/aggregators/frm.jl
@@ -70,7 +70,7 @@ end
 
 # execute one jump, changing the system state
 @inline function execute_jumps!(p::FRMJumpAggregation, integrator, u, params, t)
-  num_ma_rates = length(p.ma_jumps.scaled_rates)
+  num_ma_rates = get_num_majumps(p.ma_jumps)
   if p.next_jump <= num_ma_rates
       @inbounds executerx!(u, p.next_jump, p.ma_jumps) 
   else
@@ -104,7 +104,7 @@ end
     ttnj      = typemax(typeof(t))    
     nextrx    = zero(Int)
     majumps   = p.ma_jumps
-    @inbounds for i in eachindex(majumps.scaled_rates)
+    @inbounds for i in 1:get_num_majumps(majumps)
         p.cur_rates[i] = evalrxrate(u, i, majumps) 
         dt = randexp(p.rng) / p.cur_rates[i]
         if dt < ttnj
@@ -120,7 +120,7 @@ end
     ttnj   = typemax(typeof(t))
     nextrx = zero(Int)
     if !isempty(p.rates)
-        idx = length(p.ma_jumps.scaled_rates) + 1
+        idx = get_num_majumps(p.ma_jumps) + 1
         fill_cur_rates(u, params, t, p.cur_rates, idx, p.rates...)
         @inbounds for i in idx:length(p.cur_rates)
             dt = randexp(p.rng) / p.cur_rates[i]
@@ -138,7 +138,7 @@ end
     ttnj   = typemax(typeof(t))
     nextrx = zero(Int)
     if !isempty(p.rates)
-        idx = length(p.ma_jumps.scaled_rates) + 1  
+        idx = get_num_majumps(p.ma_jumps) + 1  
         @inbounds for i in 1:length(p.rates)
             p.cur_rates[idx] = p.rates[i](u, params, t)
             dt = randexp(p.rng) / p.cur_rates[idx]

--- a/src/aggregators/ssajump.jl
+++ b/src/aggregators/ssajump.jl
@@ -59,7 +59,7 @@ function build_jump_aggregation(jump_agg_type, u, p, t, end_time, ma_jumps, rate
   end
 
   # current jump rates, allows mass action rates and constant jumps
-  cur_rates = Vector{typeof(t)}(length(majumps.scaled_rates) + length(rates))
+  cur_rates = Vector{typeof(t)}(get_num_majumps(majumps) + length(rates))
 
   sum_rate = zero(typeof(t))
   next_jump = 0

--- a/src/aggregators/ssajump.jl
+++ b/src/aggregators/ssajump.jl
@@ -55,7 +55,7 @@ function build_jump_aggregation(jump_agg_type, u, p, t, end_time, ma_jumps, rate
   if majumps == nothing
     majumps = MassActionJump(Vector{typeof(t)}(),
                              Vector{Vector{Pair{Int,eltype(u)}}}(),
-                             Vector{Vector{Pair{Int,eltype(u)}}}() )
+                             Vector{Vector{Pair{Int,eltype(u)}}}())
   end
 
   # current jump rates, allows mass action rates and constant jumps

--- a/src/jumps.jl
+++ b/src/jumps.jl
@@ -36,12 +36,12 @@ RegularJump(rate,c,dc;mark_dist = nothing,constant_c = false) =
             RegularJump(rate,c,dc,mark_dist,constant_c)
 
 
-struct MassActionJump{T,S} <: AbstractJump
+struct MassActionJump{T,S,U} <: AbstractJump
   scaled_rates::T
   reactant_stoch::S
-  net_stoch::S
+  net_stoch::U
 
-  function MassActionJump{T,S}(rates::T, rs_in::S, ns::S, scale_rates::Bool) where {T <: AbstractVector,S}
+  function MassActionJump{T,S,U}(rates::T, rs_in::S, ns::U, scale_rates::Bool) where {T <: AbstractVector, S, U}
     sr  = copy(rates)
     rs = copy(rs_in)
     for i in eachindex(rs)
@@ -55,7 +55,7 @@ struct MassActionJump{T,S} <: AbstractJump
     end
     new(sr, rs, ns)
   end
-  function MassActionJump{T,S}(rate::T, rs_in::S, ns::S, scale_rates::Bool) where {T <: Number,S}    
+  function MassActionJump{T,S,U}(rate::T, rs_in::S, ns::U, scale_rates::Bool) where {T <: Number, S, U}    
     rs = rs_in
     if (length(rs) == 1) && (rs[1][1] == 0)
       rs = typeof(rs)()
@@ -65,7 +65,7 @@ struct MassActionJump{T,S} <: AbstractJump
   end
 
 end
-MassActionJump(usr::T, rs::S, ns::S; scale_rates = true) where {T,S} = MassActionJump{T,S}(usr, rs, ns, scale_rates)
+MassActionJump(usr::T, rs::S, ns::U; scale_rates = true) where {T,S,U} = MassActionJump{T,S,U}(usr, rs, ns, scale_rates)
 
 struct JumpSet{T1,T2,T3,T4} <: AbstractJump
   variable_jumps::T1

--- a/src/jumps.jl
+++ b/src/jumps.jl
@@ -67,6 +67,10 @@ struct MassActionJump{T,S,U} <: AbstractJump
 end
 MassActionJump(usr::T, rs::S, ns::U; scale_rates = true) where {T,S,U} = MassActionJump{T,S,U}(usr, rs, ns, scale_rates)
 
+function get_num_majumps(maj)
+  length(maj.scaled_rates)
+end
+
 struct JumpSet{T1,T2,T3,T4} <: AbstractJump
   variable_jumps::T1
   constant_jumps::T2

--- a/src/jumps.jl
+++ b/src/jumps.jl
@@ -77,7 +77,7 @@ struct JumpSet{T1,T2,T3,T4} <: AbstractJump
   regular_jump::T3
   massaction_jump::T4
 end
-JumpSet(vj, cj, rj, maj::MassActionJump{S,T}) where {S <: Number, T} = JumpSet(vj, cj, rj, check_majump_type(maj))
+JumpSet(vj, cj, rj, maj::MassActionJump{S,T,U}) where {S <: Number, T, U} = JumpSet(vj, cj, rj, check_majump_type(maj))
 
 JumpSet(jump::ConstantRateJump) = JumpSet((),(jump,),nothing,nothing)
 JumpSet(jump::VariableRateJump) = JumpSet((jump,),(),nothing,nothing)
@@ -121,20 +121,20 @@ regular_jump_combine(rj1::RegularJump,rj2::RegularJump) = error("Only one regula
 
 # functionality to merge two mass action jumps together
 check_majump_type(maj::MassActionJump) = maj
-check_majump_type(maj::MassActionJump{S,T}) where {S <: Number, T} = setup_majump_to_merge(maj.scaled_rates, maj.reactant_stoch, maj.net_stoch)
+check_majump_type(maj::MassActionJump{S,T,U}) where {S <: Number, T, U} = setup_majump_to_merge(maj.scaled_rates, maj.reactant_stoch, maj.net_stoch)
 
 # if given containers of rates and stoichiometry directly create a jump
-function setup_majump_to_merge(sr::T, rs::AbstractVector{S}, ns::AbstractVector{S}) where {T <: AbstractVector, S <: AbstractArray}
+function setup_majump_to_merge(sr::T, rs::AbstractVector{S}, ns::AbstractVector{U}) where {T <: AbstractVector, S <: AbstractArray, U <: AbstractArray}
   MassActionJump(sr, rs, ns; scale_rates=false)
 end
 
 # if just given the data for one jump (and not in a container) wrap in a vector
-function setup_majump_to_merge(sr::T, rs::S, ns::S) where {T <: Number, S <: AbstractArray}
+function setup_majump_to_merge(sr::T, rs::S, ns::U) where {T <: Number, S <: AbstractArray, U <: AbstractArray}
   MassActionJump([sr], [rs], [ns]; scale_rates=false)
 end
 
 # when given a collection of reactions to add to maj
-function majump_merge!(maj::MassActionJump{U,V}, sr::U, rs::V, ns::V) where {U <: AbstractVector, V <: AbstractVector}
+function majump_merge!(maj::MassActionJump{U,V,W}, sr::U, rs::V, ns::W) where {U <: AbstractVector, V <: AbstractVector, W <: AbstractVector}
   append!(maj.scaled_rates, sr)
   append!(maj.reactant_stoch, rs)
   append!(maj.net_stoch, ns)
@@ -142,7 +142,7 @@ function majump_merge!(maj::MassActionJump{U,V}, sr::U, rs::V, ns::V) where {U <
 end
 
 # when given a single jump's worth of data to add to maj
-function majump_merge!(maj::MassActionJump{U,V}, sr::T, rs::S, ns::S) where {U <: AbstractVector, V <: AbstractVector, T <: Number, S <: AbstractArray}
+function majump_merge!(maj::MassActionJump{U,V,W}, sr::T, rs::S1, ns::S2) where {T <: Number, S1 <: AbstractArray, S2 <: AbstractArray, U <: AbstractVector{T}, V <: AbstractVector{S1}, W <: AbstractVector{S2}}
   push!(maj.scaled_rates, sr)
   push!(maj.reactant_stoch, rs)
   push!(maj.net_stoch, ns)
@@ -151,7 +151,7 @@ end
 
 # when maj only stores a single jump's worth of data (and not in a collection)
 # create a new jump with the merged data stored in vectors
-function majump_merge!(maj::MassActionJump{T,S}, sr::T, rs::S, ns::S) where {T <: Number, S <: AbstractArray}
+function majump_merge!(maj::MassActionJump{T,S,U}, sr::T, rs::S, ns::U) where {T <: Number, S <: AbstractArray, U <: AbstractArray}
   MassActionJump([maj.scaled_rates, sr], [maj.reactant_stoch, rs], [maj.net_stoch, ns]; scale_rates=false)
 end
 

--- a/src/massaction_rates.jl
+++ b/src/massaction_rates.jl
@@ -3,7 +3,7 @@
 # stochiometric coefficient.
 ###############################################################################
 
-@fastmath function evalrxrate(speciesvec::AbstractVector{T}, rxidx::S,
+@inline @fastmath function evalrxrate(speciesvec::AbstractVector{T}, rxidx::S,
                               majump::MassActionJump{U,V,W})::R where {T,S,R,U <: AbstractVector{R},V,W} 
     val = one(T)
     @inbounds stochmat = majump.reactant_stoch[rxidx] 

--- a/src/massaction_rates.jl
+++ b/src/massaction_rates.jl
@@ -5,11 +5,8 @@
 
 @fastmath function evalrxrate(speciesvec::AbstractVector{T}, rxidx::S,  
                               majump::MassActionJump{U,V,W})::R where {T,S,R,U <: AbstractVector{R},V,W} 
-    val = one(T) 
- 
-    rateconst = majump.scaled_rates[rxidx] 
-    stochmat  = majump.reactant_stoch[rxidx] 
- 
+    val = one(T)      
+    @inbounds stochmat = majump.reactant_stoch[rxidx] 
     @inbounds for specstoch in stochmat
         specpop = speciesvec[specstoch[1]]
         val    *= specpop
@@ -19,12 +16,13 @@
         end
     end
 
-     rateconst * val
+    @inbounds rateconst = val * majump.scaled_rates[rxidx] 
+    rateconst
 end
 
 @inline @fastmath function executerx!(speciesvec::AbstractVector{T}, rxidx::S,  
                                       majump::MassActionJump{U,V,W}) where {T,S,U,V,W}
-    net_stoch = majump.net_stoch[rxidx]
+    @inbounds net_stoch = majump.net_stoch[rxidx]
     @inbounds for specstoch in net_stoch
         speciesvec[specstoch[1]] += specstoch[2]
     end

--- a/src/massaction_rates.jl
+++ b/src/massaction_rates.jl
@@ -3,10 +3,13 @@
 # stochiometric coefficient.
 ###############################################################################
 
-@fastmath function evalrxrate(speciesvec::AbstractVector{T}, rateconst,
-                              stochmat::AbstractVector{Pair{S,V}})::typeof(rateconst) where {T,S,V}
-    val = one(T)
-
+@fastmath function evalrxrate(speciesvec::AbstractVector{T}, rxidx::S,  
+                              majump::MassActionJump{U,V,W})::R where {T,S,R,U <: AbstractVector{R},V,W} 
+    val = one(T) 
+ 
+    rateconst = majump.scaled_rates[rxidx] 
+    stochmat  = majump.reactant_stoch[rxidx] 
+ 
     @inbounds for specstoch in stochmat
         specpop = speciesvec[specstoch[1]]
         val    *= specpop
@@ -19,16 +22,16 @@
      rateconst * val
 end
 
-@inline @fastmath function executerx!(speciesvec::AbstractVector{T},
-                                      net_stoch::AbstractVector{Pair{S,V}}) where {T,S,V}
+@inline @fastmath function executerx!(speciesvec::AbstractVector{T}, rxidx::S,  
+                                      majump::MassActionJump{U,V,W}) where {T,S,U,V,W}
+    net_stoch = majump.net_stoch[rxidx]
     @inbounds for specstoch in net_stoch
         speciesvec[specstoch[1]] += specstoch[2]
     end
     nothing
 end
 
-
-function scalerates!(unscaled_rates::Vector{U}, stochmat::Vector{Vector{Pair{S,T}}}) where {U,S,T}
+function scalerates!(unscaled_rates::AbstractVector{U}, stochmat::AbstractVector{V}) where {U,S,T,W <: Pair{S,T}, V <: AbstractVector{W}}
     @inbounds for i in eachindex(unscaled_rates)
         coef = one(T)
         @inbounds for specstoch in stochmat[i]
@@ -39,7 +42,7 @@ function scalerates!(unscaled_rates::Vector{U}, stochmat::Vector{Vector{Pair{S,T
     nothing
 end
 
-function scalerate(unscaled_rate::U, stochmat::Vector{Pair{S,T}}) where {U <: Number, S, T}
+function scalerate(unscaled_rate::U, stochmat::AbstractVector{Pair{S,T}}) where {U <: Number, S, T}
     coef = one(T)
     @inbounds for specstoch in stochmat
         coef *= factorial(specstoch[2])

--- a/src/massaction_rates.jl
+++ b/src/massaction_rates.jl
@@ -6,8 +6,7 @@
 @inline @fastmath function evalrxrate(speciesvec::AbstractVector{T}, rxidx::S,
                               majump::MassActionJump{U,V,W})::R where {T,S,R,U <: AbstractVector{R},V,W} 
     val = one(T)
-    @inbounds stochmat = majump.reactant_stoch[rxidx] 
-    @inbounds for specstoch in stochmat
+    @inbounds for specstoch in majump.reactant_stoch[rxidx] 
         specpop = speciesvec[specstoch[1]]
         val    *= specpop
         @inbounds for k = 2:specstoch[2]

--- a/src/massaction_rates.jl
+++ b/src/massaction_rates.jl
@@ -3,9 +3,9 @@
 # stochiometric coefficient.
 ###############################################################################
 
-@fastmath function evalrxrate(speciesvec::AbstractVector{T}, rxidx::S,  
+@fastmath function evalrxrate(speciesvec::AbstractVector{T}, rxidx::S,
                               majump::MassActionJump{U,V,W})::R where {T,S,R,U <: AbstractVector{R},V,W} 
-    val = one(T)      
+    val = one(T)
     @inbounds stochmat = majump.reactant_stoch[rxidx] 
     @inbounds for specstoch in stochmat
         specpop = speciesvec[specstoch[1]]
@@ -16,11 +16,10 @@
         end
     end
 
-    @inbounds rateconst = val * majump.scaled_rates[rxidx] 
-    rateconst
+    @inbounds return val * majump.scaled_rates[rxidx] 
 end
 
-@inline @fastmath function executerx!(speciesvec::AbstractVector{T}, rxidx::S,  
+@inline @fastmath function executerx!(speciesvec::AbstractVector{T}, rxidx::S,
                                       majump::MassActionJump{U,V,W}) where {T,S,U,V,W}
     @inbounds net_stoch = majump.net_stoch[rxidx]
     @inbounds for specstoch in net_stoch

--- a/src/problem.jl
+++ b/src/problem.jl
@@ -156,7 +156,7 @@ function Base.show(io::IO, A::JumpProblem)
   if A.regular_jump != nothing
     println(io,"Have a regular jump")
   end
-  if (A.massaction_jump != nothing) && !isempty(A.massaction_jump.scaled_rates) 
+  if (A.massaction_jump != nothing) && (get_num_majumps(A.massaction_jump) > 0)
     println(io,"Have a mass action jump")
   end
 end


### PR DESCRIPTION
Tweaks the definition of `evalrate` and `executerx!` so that aggregators don't need to know the internals of `MassActionJump`. Now just the reaction id to execute and the `MassActionJump` are passed in. The routines handle modifying/using the correct reaction. Also modifies the `MassActionJump` parametric representation to no longer require the same type for reaction stoichiometry and net stoichiometry.

This should make it easier to play with different internal `MassActionJump` implementations as aggregators don't need to be updated if the internal fields of `MassActionJump` change. (For example, I'm using this to play around with static arrays, which do seem to offer some performance benefit.)

Going forward, changing the internal representation of a `MassActionJump` should now only require updates in `jumps.jl`and in `massaction_rates.jl`. I've tried to remove any use of internal mass action jump fields outside these two files.