### PR TITLE
named `dt` parameter in `init` not forwarded

### DIFF
--- a/src/solve.jl
+++ b/src/solve.jl
@@ -12,7 +12,6 @@ function init{P,recompile_flag}(
   jump_prob::AbstractJumpProblem{P},
   alg::DEAlgorithm,timeseries=[],ts=[],ks=[],recompile::Type{Val{recompile_flag}}=Val{true};
   callback=nothing,
-  save_positions = P <: AbstractDiscreteProblem ? (false,true) : (true,true),
   kwargs...)
 
   integrator = init(jump_prob.prob,alg,timeseries,ts,ks,recompile;

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -12,7 +12,6 @@ function init{P,recompile_flag}(
   jump_prob::AbstractJumpProblem{P},
   alg::DEAlgorithm,timeseries=[],ts=[],ks=[],recompile::Type{Val{recompile_flag}}=Val{true};
   callback=nothing,
-  dt = 0,
   save_positions = P <: AbstractDiscreteProblem ? (false,true) : (true,true),
   kwargs...)
 


### PR DESCRIPTION
Fix for [#37](https://github.com/JuliaDiffEq/DiffEqJump.jl/issues/37).

Note, it seems like there could be a similar issue with the next line where the `save_positions` named parameter is set. It also isn't forwarded. Should I remove it too (or forward it)? 

I can update this PR tomorrow to fix that too if it should also be modified.