### PR TITLE
implementation of the Rejection SSA (RSSA)

### DIFF
--- a/src/DiffEqJump.jl
+++ b/src/DiffEqJump.jl
@@ -23,6 +23,8 @@ include("aggregators/direct.jl")
 include("aggregators/frm.jl")
 include("aggregators/sortingdirect.jl")
 include("aggregators/nrm.jl")
+include("aggregators/bracketing.jl")
+include("aggregators/rssa.jl")
 include("problem.jl")
 include("callbacks.jl")
 include("solve.jl")
@@ -39,7 +41,7 @@ export JumpProblem
 
 export SplitCoupledJumpProblem
 
-export Direct, DirectFW, FRM, FRMFW, SortingDirect, NRM, RSSA
+export Direct, DirectFW, FRM, FRMFW, SortingDirect, NRM, BracketData, RSSA
 
 export get_num_majumps, needs_depgraph, needs_vartojumps_map
 

--- a/src/DiffEqJump.jl
+++ b/src/DiffEqJump.jl
@@ -39,7 +39,7 @@ export JumpProblem
 
 export SplitCoupledJumpProblem
 
-export Direct, DirectFW, FRM, FRMFW, SortingDirect, NRM
+export Direct, DirectFW, FRM, FRMFW, SortingDirect, NRM, RSSA
 
 export get_num_majumps, needs_depgraph, needs_vartojumps_map
 

--- a/src/DiffEqJump.jl
+++ b/src/DiffEqJump.jl
@@ -41,7 +41,7 @@ export SplitCoupledJumpProblem
 
 export Direct, DirectFW, FRM, FRMFW, SortingDirect, NRM
 
-export get_num_majumps, needs_depgraph
+export get_num_majumps, needs_depgraph, needs_vartojumps_map
 
 export init, solve, solve!
 

--- a/src/aggregators/aggregators.jl
+++ b/src/aggregators/aggregators.jl
@@ -4,6 +4,7 @@ struct FRM <: AbstractAggregatorAlgorithm end
 struct FRMFW <: AbstractAggregatorAlgorithm end
 struct SortingDirect <: AbstractAggregatorAlgorithm end
 struct NRM <: AbstractAggregatorAlgorithm end
+struct RSSA <: AbstractAggregatorAlgorithm end
 
 # For JumpProblem construction without an aggregator
 struct NullAggregator <: AbstractAggregatorAlgorithm end

--- a/src/aggregators/aggregators.jl
+++ b/src/aggregators/aggregators.jl
@@ -1,3 +1,5 @@
+# define new aggregator algorithms here and specify their properties
+
 struct Direct <: AbstractAggregatorAlgorithm end
 struct DirectFW <: AbstractAggregatorAlgorithm end
 struct FRM <: AbstractAggregatorAlgorithm end
@@ -14,5 +16,8 @@ needs_depgraph(aggregator::AbstractAggregatorAlgorithm) = false
 needs_depgraph(aggregator::SortingDirect) = true
 needs_depgraph(aggregator::NRM) = true
 
-# true if aggregator requires a map from solution variable to dependent jumps
+# true if aggregator requires a map from solution variable to dependent jumps.
+# It is implicitly assumed these aggregators also require the reverse map, from
+# jumps to species they update.
 needs_vartojumps_map(aggregator::AbstractAggregatorAlgorithm) = false
+needs_vartojumps_map(aggregator::RSSA) = true

--- a/src/aggregators/aggregators.jl
+++ b/src/aggregators/aggregators.jl
@@ -18,6 +18,6 @@ needs_depgraph(aggregator::NRM) = true
 
 # true if aggregator requires a map from solution variable to dependent jumps.
 # It is implicitly assumed these aggregators also require the reverse map, from
-# jumps to species they update.
+# jumps to variables they update.
 needs_vartojumps_map(aggregator::AbstractAggregatorAlgorithm) = false
 needs_vartojumps_map(aggregator::RSSA) = true

--- a/src/aggregators/aggregators.jl
+++ b/src/aggregators/aggregators.jl
@@ -1,5 +1,5 @@
 struct Direct <: AbstractAggregatorAlgorithm end
-struct DirectFW <: AbstractAggregatorAlgorithm end 
+struct DirectFW <: AbstractAggregatorAlgorithm end
 struct FRM <: AbstractAggregatorAlgorithm end
 struct FRMFW <: AbstractAggregatorAlgorithm end
 struct SortingDirect <: AbstractAggregatorAlgorithm end
@@ -12,3 +12,6 @@ struct NullAggregator <: AbstractAggregatorAlgorithm end
 needs_depgraph(aggregator::AbstractAggregatorAlgorithm) = false
 needs_depgraph(aggregator::SortingDirect) = true
 needs_depgraph(aggregator::NRM) = true
+
+# true if aggregator requires a map from solution variable to dependent jumps
+needs_vartojumps_map(aggregator::AbstractAggregatorAlgorithm) = false

--- a/src/aggregators/bracketing.jl
+++ b/src/aggregators/bracketing.jl
@@ -38,12 +38,12 @@ end
 
 @inline get_majump_brackets(ulow, uhigh, k, majumps) = evalrxrate(ulow, k, majumps), evalrxrate(uhigh, k, majumps)
 
-# for constant rate jumps we must check the ordering of the bracket values`
+# for constant rate jumps we must check the ordering of the bracket values
 @inline function get_cjump_brackets(ulow, uhigh, rate, params, t)
     rlow  = rate(ulow, params, t)
     rhigh = rate(uhigh, params, t)
     if rlow <= rhigh
-        return rlow,rhigh        
+        return rlow,rhigh
     else
         return rhigh,rlow
     end

--- a/src/aggregators/bracketing.jl
+++ b/src/aggregators/bracketing.jl
@@ -1,0 +1,50 @@
+# bracketing intervals for RSSA-based aggregators
+# see: "On the rejection-based algorithm for simulation and analysis of
+#       large-scale reaction networks", Thanh et al, J. Chem. Phys., 2015
+# note, expects the type of the bracketing variables [ulow,uhigh] to be the
+# same as the fluct_rate and ushift.
+struct BracketData{T1,T2}
+    fluctrate::T1         # interval should be [1-fluctrate,1+fluctrate] * u
+    threshold::T2         # for u below threshold interval is:
+    Δu::T2                #   [max(u-Δu,0),u+Δu]
+end
+
+# # suggested defaults
+# BracketData{T1}() = BracketData(.1, 25, 4)
+BracketData{T1,T2}() where {T1,T2} = BracketData(T1(.1),T2(25),T2(4))
+
+# support either vectors of data for each field, or scalars
+@inline getfr(bd::BracketData{AbstractVector{T1},T2}, i) where {T1,T2} = bd.fluctrate[i]
+@inline getfr(bd::BracketData{T1,T2}, i) where {T1 <: Number,T2} = bd.fluctrate
+
+@inline gettv(bd::BracketData{T1,AbstractVector{T2}}, i) where {T1,T2} = bd.threshold[i]
+@inline gettv(bd::BracketData{T1,T2}, i) where {T1,T2 <: Number} = bd.threshold
+
+@inline getΔu(bd::BracketData{T1,AbstractVector{T2}}, i) where {T1,T2} = bd.Δu[i]
+@inline getΔu(bd::BracketData{T1,T2}, i) where {T1,T2 <: Number} = bd.Δu
+
+
+@inline function get_spec_brackets(bd, i, u)
+    if u == zero(u)
+        return zero(u), zero(u)
+    elseif u < gettv(bd, i)
+        Δu = getΔu(bd,i)
+        return max(zero(Δu), u - Δu), u + Δu
+    else
+        δ = getfr(bd, i)
+        return trunc(typeof(u), (one(δ) - δ) * u), trunc(typeof(u), (one(δ) + δ) * u)
+    end
+end
+
+@inline get_majump_brackets(ulow, uhigh, k, majumps) = evalrxrate(ulow, k, majumps), evalrxrate(uhigh, k, majumps)
+
+# for constant rate jumps we must check the ordering of the bracket values`
+@inline function get_cjump_brackets(ulow, uhigh, rate, params, t)
+    rlow  = rate(ulow, params, t)
+    rhigh = rate(uhigh, params, t)
+    if rlow <= rhigh
+        return rlow,rhigh        
+    else
+        return rhigh,rlow
+    end
+end

--- a/src/aggregators/direct.jl
+++ b/src/aggregators/direct.jl
@@ -9,22 +9,22 @@ mutable struct DirectJumpAggregation{T,S,F1,F2,RNG} <: AbstractSSAJumpAggregator
   affects!::F2
   save_positions::Tuple{Bool,Bool}
   rng::RNG
-  DirectJumpAggregation{T,S,F1,F2,RNG}(nj::Int, njt::T, et::T, crs::Vector{T}, sr::T, maj::S, rs::F1, affs!::F2, sps::Tuple{Bool,Bool}, rng::RNG) where {T,S,F1,F2,RNG} = 
+  DirectJumpAggregation{T,S,F1,F2,RNG}(nj::Int, njt::T, et::T, crs::Vector{T}, sr::T, maj::S, rs::F1, affs!::F2, sps::Tuple{Bool,Bool}, rng::RNG) where {T,S,F1,F2,RNG} =
     new{T,S,F1,F2,RNG}(nj, njt, et, crs, sr, maj, rs, affs!, sps, rng)
 end
-DirectJumpAggregation(nj::Int, njt::T, et::T, crs::Vector{T}, sr::T, maj::S, rs::F1, affs!::F2, sps::Tuple{Bool,Bool}, rng::RNG; kwargs...) where {T,S,F1,F2,RNG} = 
+DirectJumpAggregation(nj::Int, njt::T, et::T, crs::Vector{T}, sr::T, maj::S, rs::F1, affs!::F2, sps::Tuple{Bool,Bool}, rng::RNG; kwargs...) where {T,S,F1,F2,RNG} =
   DirectJumpAggregation{T,S,F1,F2,RNG}(nj, njt, et, crs, sr, maj, rs, affs!, sps, rng)
 
 
 ########### The following routines should be templates for all SSAs ###########
 
 # condition for jump to occur
-@inline function (p::DirectJumpAggregation)(u, t, integrator) 
+@inline function (p::DirectJumpAggregation)(u, t, integrator)
   p.next_jump_time == t
 end
 
 # executing jump at the next jump time
-function (p::DirectJumpAggregation)(integrator) 
+function (p::DirectJumpAggregation)(integrator)
   execute_jumps!(p, integrator, integrator.u, integrator.p, integrator.t)
   generate_jumps!(p, integrator, integrator.u, integrator.p, integrator.t)
   register_next_jump_time!(integrator, p, integrator.t)
@@ -41,24 +41,24 @@ end
 ############################# Required Functions #############################
 
 # creating the JumpAggregation structure (tuple-based constant jumps)
-function aggregate(aggregator::Direct, u, p, t, end_time, constant_jumps, 
+function aggregate(aggregator::Direct, u, p, t, end_time, constant_jumps,
                     ma_jumps, save_positions, rng; kwargs...)
 
   # handle constant jumps using tuples
   rates, affects! = get_jump_info_tuples(constant_jumps)
 
-  build_jump_aggregation(DirectJumpAggregation, u, p, t, end_time, ma_jumps, 
+  build_jump_aggregation(DirectJumpAggregation, u, p, t, end_time, ma_jumps,
                           rates, affects!, save_positions, rng; kwargs...)
 end
 
 # creating the JumpAggregation structure (function wrapper-based constant jumps)
-function aggregate(aggregator::DirectFW, u, p, t, end_time, constant_jumps, 
+function aggregate(aggregator::DirectFW, u, p, t, end_time, constant_jumps,
                     ma_jumps, save_positions, rng; kwargs...)
 
   # handle constant jumps using function wrappers
   rates, affects! = get_jump_info_fwrappers(u, p, t, constant_jumps)
 
-  build_jump_aggregation(DirectJumpAggregation, u, p, t, end_time, ma_jumps, 
+  build_jump_aggregation(DirectJumpAggregation, u, p, t, end_time, ma_jumps,
                           rates, affects!, save_positions, rng; kwargs...)
 end
 
@@ -72,7 +72,7 @@ end
 @inline function execute_jumps!(p::DirectJumpAggregation, integrator, u, params, t)
   num_ma_rates = get_num_majumps(p.ma_jumps)
   if p.next_jump <= num_ma_rates
-      @inbounds executerx!(u, p.next_jump, p.ma_jumps) 
+      @inbounds executerx!(u, p.next_jump, p.ma_jumps)
   else
       idx = p.next_jump - num_ma_rates
       @inbounds p.affects![idx](integrator)
@@ -101,12 +101,12 @@ end
   majumps   = p.ma_jumps
   idx       = get_num_majumps(majumps)
   @inbounds for i in 1:idx
-    new_rate     = evalrxrate(u, i, majumps) 
+    new_rate     = evalrxrate(u, i, majumps)
     cur_rates[i] = new_rate + prev_rate
     prev_rate    = cur_rates[i]
   end
-  
-  # constant jump rates  
+
+  # constant jump rates
   rates = p.rates
   if !isempty(rates)
     idx  += 1
@@ -143,7 +143,7 @@ end
   majumps   = p.ma_jumps
   idx       = get_num_majumps(majumps)
   @inbounds for i in 1:idx
-    new_rate     = evalrxrate(u, i, majumps) 
+    new_rate     = evalrxrate(u, i, majumps)
     cur_rates[i] = new_rate + prev_rate
     prev_rate    = cur_rates[i]
   end
@@ -161,4 +161,3 @@ end
   @inbounds sum_rate = cur_rates[end]
   sum_rate, randexp(p.rng) / sum_rate
 end
-

--- a/src/aggregators/rssa.jl
+++ b/src/aggregators/rssa.jl
@@ -22,7 +22,6 @@ mutable struct RSSAJumpAggregation{T,T2,S,F1,F2,RNG,VJMAP,JVMAP,BD,T2V} <: Abstr
     bracket_data::BD
     ulow::T2V
     uhigh::T2V
-    eventcnt::Int
   end
 
 function RSSAJumpAggregation(nj::Int, njt::T, et::T, crs::Vector{T}, sr::T,
@@ -51,14 +50,14 @@ function RSSAJumpAggregation(nj::Int, njt::T, et::T, crs::Vector{T}, sr::T,
     bd = (bracket_data == nothing) ? BracketData{T,eltype(U)}() : bracket_data
 
     # matrix to store bracketing interval for species and the relative interval width
-    # first row is fluct rate, δᵢ, then Xlow then Xhigh
+    # first row is Xlow, second is Xhigh
     cs_bnds = Matrix{eltype(U)}(undef, 2, length(u))
     ulow    = @view cs_bnds[1,:]
     uhigh   = @view cs_bnds[2,:]
 
     RSSAJumpAggregation{T,eltype(U),S,F1,F2,RNG,typeof(vtoj_map),typeof(jtov_map),typeof(bd),typeof(ulow)}(
                         nj, njt, et, crl_bnds, crh_bnds, sr, cs_bnds, maj, rs,
-                        affs!, sps, rng, vtoj_map, jtov_map, bd, ulow, uhigh, 0)
+                        affs!, sps, rng, vtoj_map, jtov_map, bd, ulow, uhigh)
 end
 
 
@@ -74,7 +73,6 @@ function (p::RSSAJumpAggregation)(integrator)
     execute_jumps!(p, integrator, integrator.u, integrator.p, integrator.t)
     generate_jumps!(p, integrator, integrator.u, integrator.p, integrator.t)
     register_next_jump_time!(integrator, p, integrator.t)
-    p.eventcnt += 1
     nothing
 end
 

--- a/src/aggregators/rssa.jl
+++ b/src/aggregators/rssa.jl
@@ -126,7 +126,7 @@ function initialize!(p::RSSAJumpAggregation, integrator, u, params, t)
         sum_rate += crhigh[k]
         k += 1
     end
-    p.sum_rate       = sum_rate
+    p.sum_rate = sum_rate
 
     generate_jumps!(p, integrator, u, params, t)
     nothing
@@ -213,7 +213,7 @@ end
                     notdone = false
                 end
             else
-                @inbounds crate = rate[jidx - num_majumps](u, params, t)
+                @inbounds crate = p.rates[jidx - num_majumps](u, params, t)
                 if crate > zero(crate) && r2 <= crate
                     notdone = false
                 end

--- a/src/aggregators/rssa.jl
+++ b/src/aggregators/rssa.jl
@@ -1,0 +1,225 @@
+# Rejection SSA Method (RSSA), implementation following:
+# Marchetti, Priami and Thanh - Simulation Algorithms for Computational Systems Biology
+# Note, this implementation **assumes** jump rate functions are monotone
+# functions of the current population sizes (i.e. u)
+# requires vartojumps_map and fluct_rates as JumpProblem keywords
+
+mutable struct RSSAJumpAggregation{T,T2,S,F1,F2,RNG,VJMAP,JVMAP} <: AbstractSSAJumpAggregator
+    next_jump::Int
+    next_jump_time::T
+    end_time::T
+    cur_rate_low::Vector{T}
+    cur_rate_high::Vector{T}
+    sum_rate::T
+    cur_u_bnds::Matrix{T2}
+    ma_jumps::S
+    rates::F1
+    affects!::F2
+    save_positions::Tuple{Bool,Bool}
+    rng::RNG
+    vartojumps_map::VJMAP
+    jumptovars_map::JVMAP
+  end
+
+function RSSAJumpAggregation(nj::Int, njt::T, et::T, crs::Vector{T}, sr::T,
+                                      maj::S, rs::F1, affs!::F2, sps::Tuple{Bool,Bool},
+                                      rng::RNG; vartojumps_map=nothing, jumptovars_map=nothing,
+                                      fluct_rates=nothing, kwargs...) where {T,S,F1,F2,RNG}
+
+    # a dependency graph is needed and must be provided if there are constant rate jumps
+    if varstojumps_map == nothing
+        error("To use the RSSA algorithm a map from variables to depedent jumps must be supplied.")
+    else
+        vtoj_map = vartojumps_map
+    end
+
+    if jumptovars_map == nothing
+        error("To use the RSSA algorithm a map from jumps to dependent variables must be supplied.")
+    else
+        jtov_map = jumptovars_map
+    end
+
+    # matrix to store bracketing intervals for jump rates
+    crl_bnds = Vector{T}(undef, length(crs))
+    crh_bnds = Vector{T}(undef, length(crs))
+
+    # matrix to store bracketing interval for species and the relative interval width
+    # first row is fluct rate, δᵢ, then Xlow then Xhigh
+    cs_bnds = Matrix{eltype(frs)}(undef, 3, length(u))
+
+    # fluctuation rates for how big to take the species bracketing interval are required
+    if fluct_rates == nothing
+        error("To use the RSSA algorithm a vector of fluctuation rates must be supplied.")
+    else
+        cs_bnds[1,:] .= fluct_rates
+    end
+
+    RSSAJumpAggregation{T,S,F1,F2,RNG,typeof(dg)}(nj, njt, et, crl_bnds, crl_bnds,
+                                                  sr, cs_bnds, maj, rs, affs!,
+                                                  sps, rng, vtoj_map, jtov_map)
+end
+
+
+########### The following routines should be templates for all SSAs ###########
+
+# condition for jump to occur
+@inline function (p::RSSAJumpAggregation)(u, t, integrator)
+    p.next_jump_time == t
+end
+
+# executing jump at the next jump time
+function (p::RSSAJumpAggregation)(integrator)
+    execute_jumps!(p, integrator, integrator.u, integrator.p, integrator.t)
+    generate_jumps!(p, integrator, integrator.u, integrator.p, integrator.t)
+    register_next_jump_time!(integrator, p, integrator.t)
+    nothing
+end
+
+# setting up a new simulation
+function (p::RSSAJumpAggregation)(dj, u, t, integrator) # initialize
+    initialize!(p, integrator, u, integrator.p, t)
+    register_next_jump_time!(integrator, p, t)
+    nothing
+end
+
+############################# Required Functions ##############################
+
+# creating the JumpAggregation structure (function wrapper-based constant jumps)
+function aggregate(aggregator::RSSA, u, p, t, end_time, constant_jumps,
+                   ma_jumps, save_positions, rng; kwargs...)
+
+    # handle constant jumps using function wrappers
+    rates, affects! = get_jump_info_fwrappers(u, p, t, constant_jumps)
+
+    build_jump_aggregation(RSSAJumpAggregation, u, p, t, end_time, ma_jumps,
+                           rates, affects!, save_positions, rng; kwargs...)
+end
+
+# set up a new simulation and calculate the first jump / jump time
+function initialize!(p::RSSAJumpAggregation, integrator, u, params, t)
+
+    # species bracketing interval
+    ubnds = p.cur_u_bnds
+    @inbounds for i = 1:length(u)
+        ubnds[2,i],ubnds[3,i] = get_spec_brackets(u[i], ubnds[1,i])
+    end
+
+    # reaction rate bracketing interval
+    # mass action jumps
+    sum_rate = zero(typeof(p.sum_rate))
+    majumps  = p.majumps
+    crlow    = p.cur_rate_low
+    crhigh   = p.cur_rate_high
+    ulow     = @view ubnds[2,:]
+    uhigh    = @view ubnds[3,:]
+    @inbounds for k = 1:get_num_majumps(majumps)
+        crlow[k],crhigh[k] = get_majump_brackets(ulow, uhigh, k, majumps)
+        sum_rate += crhigh[k]
+    end
+
+    # constant rate jumps
+    k = get_num_majumps(majumps) + 1
+    @inbounds for rate in p.rates
+        crlow[k], crhigh[k] = get_cjump_brackets(ulow, uhigh, rate, params, t)
+        sum_rate += crhigh[k]
+        k += 1
+    end
+    p.sum_rate = sum_rate
+
+    generate_jumps!(p, integrator, u, params, t)
+    nothing
+end
+
+# execute one jump, changing the system state
+function execute_jumps!(p::RSSAJumpAggregation, integrator, u, params, t)
+    # execute jump
+    num_ma_rates = get_num_majumps(p.ma_jumps)
+    if p.next_jump <= num_ma_rates
+        @inbounds executerx!(u, p.next_jump, p.ma_jumps)
+    else
+        idx = p.next_jump - num_ma_rates
+        @inbounds p.affects![idx](integrator)
+    end
+
+    # update bracketing intervals
+    ubnds       = p.cur_u_bnds
+    sum_rate    = p.sum_rate
+    crlow       = p.cur_rate_low
+    crhigh      = p.cur_rate_high
+    majumps     = p.majumps
+    num_majumps = get_num_majumps(majumps)
+    @inbounds ulow  = @view ubnds[2,:]
+    @inbounds uhigh = @view ubnds[3,:]
+    @inbounds for uidx in p.jumptovars_map[p.next_jump]
+        uval = u[uidx]
+
+        # if new u value is outside the bracketing interval
+        if (uval < ubnds[2,uidx]) || (uval > ubnds[3,uidx])
+            # update u bracketing interval
+            ubnds[2,uidx],ubnds[3,uidx] = get_spec_brackets(u[uidx], ubnds[1,uidx])
+
+            # for each dependent jump, update jump rate brackets
+            @inbounds for jidx in p.varstojumps_map[uidx]
+                sum_rate -= crhigh[jidx]
+                if jidx <= num_majumps
+                    crlow[jidx],crhigh[jidx] = get_majump_brackets(ulow, uhigh, jidx, majumps)
+                else
+                    j = jidx - num_majumps
+                    crlow[jidx],crhigh[jidx] = get_cjump_brackets(ulow, uhigh, p.rates[j], params, t)
+                end
+                sum_rate += crhigh[jidx]
+            end
+        end
+    end
+    p.sum_rate = sum_rate
+
+    nothing
+end
+
+# calculate the next jump / jump time
+function generate_jumps!(p::RSSAJumpAggregation, integrator, u, params, t)
+    @fastmath p.next_jump_time = t + calc_next_jump!(p, u, params, t)
+    nothing
+end
+
+
+######################## SSA specific helper routines #########################
+
+# searches for the next reaction using rejection
+@fastmath function calc_next_jump!(p, u, params, t)
+
+    # next jump type
+    rprod       = one(typeof(sum_rate))
+    crlow       = p.cur_rate_low
+    crhigh      = p.cur_rate_high
+    majumps     = p.majumps
+    num_majumps = get_num_majumps(majumps)
+    notdone     = true
+    @inbounds while notdone
+        # sample candidate reaction
+        r      = rand(p.rng) * sum_rate
+        jidx   = 1
+        parsum = crhigh[jidx]
+        while parsum < r
+            jidx   += 1
+            parsum += crhigh[jidx]
+        end
+
+        # rejection test
+        r2 = rand(p.rng) * crhigh[jidx]
+        if r2 <= crlow[jidx]
+            notdone = false
+        else
+            # calculate actual propensity
+            crate = (jidx <= num_majumps) ? evalrxrate(u, jidx, majumps) : rate[jidx - num_majumps](u, params, t)
+            if r2 <= crate
+                notdone = false
+            end
+        end
+        rprod *= rand(p.rng)
+    end
+     p.next_jump = jidx
+
+    # return time to next jump
+    return (-one(typeof(p.sum_rate)) / p.sum_rate) * log(rprod)
+end

--- a/src/aggregators/ssajump.jl
+++ b/src/aggregators/ssajump.jl
@@ -116,3 +116,19 @@ function update_dependent_rates!(p::AbstractSSAJumpAggregator, u, params, t)
   p.sum_rate = sum_rate
   nothing
 end
+
+
+########## bracket interval routines for rejection methods ############
+inline get_spec_brackets(uval, δ) = (one(eltype(δ)) - δ) * uval, (one(eltype(δ)) + δ) * uval
+inline get_majump_brackets(ulow, uhigh, k, majumps) = evalrxrate(ulow, k, majumps), evalrxrate(uhigh, k, majumps)
+
+# for constant rate jumps we must check the ordering of the bracket values`
+inline function get_cjump_brackets(ulow, uhigh, rate, params, t)
+    rlow  = rate(ulow, params, t)
+    rhigh = rate(uhigh, params, t)
+    if rlow > rhigh
+        return rhigh,rlow
+    else
+        return rlow,rhigh
+    end
+end

--- a/src/aggregators/ssajump.jl
+++ b/src/aggregators/ssajump.jl
@@ -116,19 +116,3 @@ function update_dependent_rates!(p::AbstractSSAJumpAggregator, u, params, t)
   p.sum_rate = sum_rate
   nothing
 end
-
-
-########## bracket interval routines for rejection methods ############
-inline get_spec_brackets(uval, δ) = (one(eltype(δ)) - δ) * uval, (one(eltype(δ)) + δ) * uval
-inline get_majump_brackets(ulow, uhigh, k, majumps) = evalrxrate(ulow, k, majumps), evalrxrate(uhigh, k, majumps)
-
-# for constant rate jumps we must check the ordering of the bracket values`
-inline function get_cjump_brackets(ulow, uhigh, rate, params, t)
-    rlow  = rate(ulow, params, t)
-    rhigh = rate(uhigh, params, t)
-    if rlow > rhigh
-        return rhigh,rlow
-    else
-        return rlow,rhigh
-    end
-end

--- a/src/jumps.jl
+++ b/src/jumps.jl
@@ -67,7 +67,7 @@ struct MassActionJump{T,S,U} <: AbstractJump
 end
 MassActionJump(usr::T, rs::S, ns::U; scale_rates = true) where {T,S,U} = MassActionJump{T,S,U}(usr, rs, ns, scale_rates)
 
-function get_num_majumps(maj)
+function get_num_majumps(maj::MassActionJump)
   length(maj.scaled_rates)
 end
 
@@ -102,6 +102,9 @@ function JumpSet(vjs, cjs, rj, majv::Vector{T}) where {T <: MassActionJump}
 
   JumpSet(vjs, cjs, rj, maj)
 end
+
+get_num_majumps(jset::JumpSet) = get_num_majumps(jset.massaction_jump)
+
 
 @inline split_jumps(vj, cj, rj, maj) = vj, cj, rj, maj
 @inline split_jumps(vj, cj, rj, maj, v::VariableRateJump, args...) = split_jumps((vj..., v), cj, rj, maj, args...)
@@ -174,13 +177,6 @@ function get_jump_info_tuples(constant_jumps)
   rates, affects!
 end
 
-#=
-function get_jump_info_fwrappers(u, p, t, constant_jumps)
-  error("Use of FunctionWrappers is disabled until they update for v0.7")
-end
-=#
-
-
 function get_jump_info_fwrappers(u, p, t, constant_jumps)
   RateWrapper   = FunctionWrappers.FunctionWrapper{typeof(t),Tuple{typeof(u), typeof(p), typeof(t)}}
   AffectWrapper = FunctionWrappers.FunctionWrapper{Nothing,Tuple{Any}}
@@ -195,4 +191,3 @@ function get_jump_info_fwrappers(u, p, t, constant_jumps)
 
   rates, affects!
 end
-

--- a/src/jumps.jl
+++ b/src/jumps.jl
@@ -67,9 +67,8 @@ struct MassActionJump{T,S,U} <: AbstractJump
 end
 MassActionJump(usr::T, rs::S, ns::U; scale_rates = true) where {T,S,U} = MassActionJump{T,S,U}(usr, rs, ns, scale_rates)
 
-function get_num_majumps(maj::MassActionJump)
-  length(maj.scaled_rates)
-end
+get_num_majumps(maj::MassActionJump) = length(maj.scaled_rates)
+
 
 struct JumpSet{T1,T2,T3,T4} <: AbstractJump
   variable_jumps::T1

--- a/src/jumps.jl
+++ b/src/jumps.jl
@@ -102,7 +102,7 @@ function JumpSet(vjs, cjs, rj, majv::Vector{T}) where {T <: MassActionJump}
   JumpSet(vjs, cjs, rj, maj)
 end
 
-get_num_majumps(jset::JumpSet) = get_num_majumps(jset.massaction_jump)
+@inline get_num_majumps(jset::JumpSet) = get_num_majumps(jset.massaction_jump)
 
 
 @inline split_jumps(vj, cj, rj, maj) = vj, cj, rj, maj

--- a/src/jumps.jl
+++ b/src/jumps.jl
@@ -67,7 +67,7 @@ struct MassActionJump{T,S,U} <: AbstractJump
 end
 MassActionJump(usr::T, rs::S, ns::U; scale_rates = true) where {T,S,U} = MassActionJump{T,S,U}(usr, rs, ns, scale_rates)
 
-get_num_majumps(maj::MassActionJump) = length(maj.scaled_rates)
+@inline get_num_majumps(maj::MassActionJump) = length(maj.scaled_rates)
 
 
 struct JumpSet{T1,T2,T3,T4} <: AbstractJump

--- a/test/bimolerx_test.jl
+++ b/test/bimolerx_test.jl
@@ -1,5 +1,5 @@
 using DiffEqBase, DiffEqJump
-using Test
+using Test, Statistics
 
 # using Plots; plotlyjs()
 doplot = false
@@ -11,7 +11,7 @@ dotestmean   = true
 doprintmeans = false
 
 # SSAs to test
-SSAalgs = (Direct(), DirectFW(), FRM(), FRMFW(), SortingDirect(), NRM())
+SSAalgs = (Direct(), DirectFW(), FRM(), FRMFW(), SortingDirect(), NRM(), RSSA())
 
 Nsims        = 32000
 tf           = .01
@@ -49,6 +49,8 @@ netstoch =
     [1 => 3, 3 => -3]
 ]
 rates = [1., 2., .5, .75, .25]
+spec_to_dep_jumps = [[1,3],[2,3],[4,5]]
+jump_to_dep_specs = [[1,2],[1,2],[1,2,3],[1,2,3],[1,3]]
 majumps = MassActionJump(rates, reactstoch, netstoch)
 
 # average number of proteins in a simulation
@@ -67,7 +69,7 @@ prob = DiscreteProblem(u0, (0.0, tf), rates)
 # plotting one full trajectory
 if doplot
     for alg in SSAalgs
-        jump_prob = JumpProblem(prob, alg, majumps)
+        jump_prob = JumpProblem(prob, alg, majumps, vartojumps_map=spec_to_dep_jumps, jumptovars_map=jump_to_dep_specs)
         sol = solve(jump_prob, SSAStepper())
         plothand = plot(sol, seriestype=:steppost, reuse=false)
         display(plothand)
@@ -78,7 +80,7 @@ end
 if dotestmean
     means = zeros(Float64,length(SSAalgs))
     for (i,alg) in enumerate(SSAalgs)
-        jump_prob = JumpProblem(prob, alg, majumps, save_positions=(false,false))
+        jump_prob = JumpProblem(prob, alg, majumps, save_positions=(false,false), vartojumps_map=spec_to_dep_jumps, jumptovars_map=jump_to_dep_specs)
         means[i]  = runSSAs(jump_prob)
         relerr = abs(means[i] - expected_avg) / expected_avg
         if doprintmeans
@@ -100,7 +102,7 @@ end
 #     # exact methods
 #     for alg in SSAalgs
 #         println("Solving with method: ", typeof(alg), ", using SSAStepper")
-#         jump_prob = JumpProblem(prob, alg, majumps)
+#         jump_prob = JumpProblem(prob, alg, majumps, vartojumps_map=spec_to_dep_jumps, jumptovars_map=jump_to_dep_specs)
 #         @btime solve($jump_prob, SSAStepper())
 #     end
 #     println()
@@ -115,7 +117,7 @@ if dotestmean
         push!(majump_vec, MassActionJump(rates[i], reactstoch[i], netstoch[i]))
     end
     jset = JumpSet((),(),nothing,majump_vec)
-    jump_prob = JumpProblem(prob, Direct(), jset, save_positions=(false,false))
+    jump_prob = JumpProblem(prob, Direct(), jset, save_positions=(false,false), vartojumps_map=spec_to_dep_jumps, jumptovars_map=jump_to_dep_specs)
     meanval = runSSAs(jump_prob)
     relerr = abs(meanval - expected_avg) / expected_avg
     if doprintmeans

--- a/test/degenerate_rx_cases.jl
+++ b/test/degenerate_rx_cases.jl
@@ -10,7 +10,7 @@ doprint = false
 #using Plots; plotlyjs()
 doplot = false
 
-methods = (Direct(), DirectFW(), FRM(), FRMFW(), SortingDirect(), NRM())
+methods = (Direct(), DirectFW(), FRM(), FRMFW(), SortingDirect(), NRM(), RSSA())
 
 # one reaction case, mass action jump, vector of data
 rate = [2.0]
@@ -94,9 +94,12 @@ dep_graph = [
     [1, 2],
     [1, 2]
 ]
+spec_to_dep_jumps = [[2]]
+jump_to_dep_specs = [[1],[1]]
+namedpars = (dep_graph=dep_graph, vartojumps_map=spec_to_dep_jumps, jumptovars_map=jump_to_dep_specs)
 
 for method in methods
-    jump_prob = JumpProblem(prob, method, jump, jump2; dep_graph=dep_graph)
+    jump_prob = JumpProblem(prob, method, jump, jump2; namedpars...)
     sol = solve(jump_prob, SSAStepper())
 
     if doplot

--- a/test/geneexpr_test.jl
+++ b/test/geneexpr_test.jl
@@ -3,11 +3,11 @@ using Test, Statistics
 
 # using Plots; plotlyjs()
 doplot = false
-# using BenchmarkTools
-# dobenchmark = false
+using BenchmarkTools
+dobenchmark = false
 
 dotestmean   = true
-doprintmeans = true
+doprintmeans = false
 
 # SSAs to test
 SSAalgs = (Direct(), SortingDirect(), NRM(), RSSA()) #, DirectFW(), FRM(), FRMFW()),
@@ -104,12 +104,12 @@ end
 
 
 # # benchmark performance
-# if dobenchmark
-#     # exact methods
-#     for alg in SSAalgs
-#         println("Solving with method: ", typeof(alg), ", using SSAStepper")
-#         jump_prob = JumpProblem(prob, alg, majumps, vartojumps_map=spec_to_dep_jumps, jumptovars_map=jump_to_dep_specs)
-#         @btime solve($jump_prob, SSAStepper())
-#     end
-#     println()
-# end
+if dobenchmark
+    # exact methods
+    for alg in SSAalgs
+        println("Solving with method: ", typeof(alg), ", using SSAStepper")
+        jump_prob = JumpProblem(prob, alg, majumps, vartojumps_map=spec_to_dep_jumps, jumptovars_map=jump_to_dep_specs)
+        @btime solve($jump_prob, SSAStepper())
+    end
+    println()
+end

--- a/test/geneexpr_test.jl
+++ b/test/geneexpr_test.jl
@@ -1,5 +1,5 @@
 using DiffEqBase, DiffEqJump
-using Test
+using Test, Statistics
 
 # using Plots; plotlyjs()
 doplot = false
@@ -7,11 +7,12 @@ doplot = false
 # dobenchmark = false
 
 dotestmean   = true
-doprintmeans = false
+doprintmeans = true
 
 # SSAs to test
-SSAalgs = (Direct(), SortingDirect(), NRM()) #, DirectFW(), FRM(), FRMFW()), 
+SSAalgs = (Direct(), SortingDirect(), NRM(), RSSA()) #, DirectFW(), FRM(), FRMFW()),
 
+# numerical parameters
 Nsims        = 8000
 tf           = 1000.0
 u0           = [1,0,0,0]
@@ -61,6 +62,8 @@ netstoch =
     [1 => -1, 3 => -1, 4 => 1],
     [1 => 1, 3 => 1, 4 => -1]
 ]
+spec_to_dep_jumps = [[1,5],[2,3],[4,5],[6]]
+jump_to_dep_specs = [[2],[3],[2],[3],[1,3,4],[1,3,4]]
 rates = [.5, (20*log(2.)/120.), (log(2.)/120.), (log(2.)/600.), .025, 1.]
 majumps = MassActionJump(rates, reactstoch, netstoch)
 
@@ -72,7 +75,7 @@ prob = DiscreteProblem(u0, (0.0, tf), rates)
 if doplot
     plothand = plot(reuse=false)
     for alg in SSAalgs
-        jump_prob = JumpProblem(prob, alg, majumps)
+        jump_prob = JumpProblem(prob, alg, majumps, vartojumps_map=spec_to_dep_jumps, jumptovars_map=jump_to_dep_specs)
         sol = solve(jump_prob, SSAStepper())
         plot!(plothand, sol.t, sol[3,:], seriestype=:steppost)
     end
@@ -83,7 +86,7 @@ end
 if dotestmean
     means = zeros(Float64,length(SSAalgs))
     for (i,alg) in enumerate(SSAalgs)
-        jump_prob = JumpProblem(prob, alg, majumps, save_positions=(false,false))
+        jump_prob = JumpProblem(prob, alg, majumps, save_positions=(false,false), vartojumps_map=spec_to_dep_jumps, jumptovars_map=jump_to_dep_specs)
         means[i]  = runSSAs(jump_prob)
         relerr = abs(means[i] - expected_avg) / expected_avg
         if doprintmeans
@@ -105,7 +108,7 @@ end
 #     # exact methods
 #     for alg in SSAalgs
 #         println("Solving with method: ", typeof(alg), ", using SSAStepper")
-#         jump_prob = JumpProblem(prob, alg, majumps)
+#         jump_prob = JumpProblem(prob, alg, majumps, vartojumps_map=spec_to_dep_jumps, jumptovars_map=jump_to_dep_specs)
 #         @btime solve($jump_prob, SSAStepper())
 #     end
 #     println()

--- a/test/geneexpr_test.jl
+++ b/test/geneexpr_test.jl
@@ -3,8 +3,8 @@ using Test, Statistics
 
 # using Plots; plotlyjs()
 doplot = false
-using BenchmarkTools
-dobenchmark = false
+# using BenchmarkTools
+# dobenchmark = false
 
 dotestmean   = true
 doprintmeans = false
@@ -97,19 +97,18 @@ if dotestmean
         #     @btime (runSSAs($jump_prob);)
         # end
 
-
         @test abs(means[i] - expected_avg) < reltol*expected_avg
     end
 end
 
 
 # # benchmark performance
-if dobenchmark
-    # exact methods
-    for alg in SSAalgs
-        println("Solving with method: ", typeof(alg), ", using SSAStepper")
-        jump_prob = JumpProblem(prob, alg, majumps, vartojumps_map=spec_to_dep_jumps, jumptovars_map=jump_to_dep_specs)
-        @btime solve($jump_prob, SSAStepper())
-    end
-    println()
-end
+# if dobenchmark
+#     # exact methods
+#     for alg in SSAalgs
+#         println("Solving with method: ", typeof(alg), ", using SSAStepper")
+#         jump_prob = JumpProblem(prob, alg, majumps, vartojumps_map=spec_to_dep_jumps, jumptovars_map=jump_to_dep_specs)
+#         @btime solve($jump_prob, SSAStepper())
+#     end
+#     println()
+# end

--- a/test/linearreaction_test.jl
+++ b/test/linearreaction_test.jl
@@ -14,8 +14,11 @@ tf          = .1
 baserate    = .1
 A0          = 100
 exactmean   = (t,ratevec) -> A0 * exp(-sum(ratevec) * t)
-SSAalgs     = [Direct()]#, DirectFW(), FRM(), FRMFW()]
+SSAalgs     = [Direct(),RSSA()] #[Direct(),RSSA()]#, DirectFW(), FRM(), FRMFW()]
 
+spec_to_dep_jumps = [collect(1:Nrxs),[]]
+jump_to_dep_specs = [[1,2] for i=1:Nrxs]
+namedpars = (vartojumps_map=spec_to_dep_jumps, jumptovars_map=jump_to_dep_specs)
 rates = ones(Float64, Nrxs) * baserate;
 cumsum!(rates, rates)
 exactmeanval = exactmean(tf, rates)
@@ -47,7 +50,7 @@ function A_to_B_tuple(N, method)
     jumps     = ((jump for jump in jumpvec)...,)
     jset      = JumpSet((), jumps, nothing, nothing)
     prob      = DiscreteProblem([A0,0], (0.0,tf))
-    jump_prob = JumpProblem(prob, method, jset; save_positions=(false,false))
+    jump_prob = JumpProblem(prob, method, jset; save_positions=(false,false), namedpars...)
 
     jump_prob
 end
@@ -68,7 +71,7 @@ function A_to_B_vec(N, method)
     # convert jumpvec to tuple to send to JumpProblem...
     jset      = JumpSet((), jumps, nothing, nothing)
     prob      = DiscreteProblem([A0,0], (0.0,tf))
-    jump_prob = JumpProblem(prob, method, jset; save_positions=(false,false))
+    jump_prob = JumpProblem(prob, method, jset; save_positions=(false,false), namedpars...)
 
     jump_prob
 end
@@ -85,7 +88,7 @@ function A_to_B_ma(N, method)
     majumps   = MassActionJump(rates, reactstoch, netstoch)
     jset      = JumpSet((), (), nothing, majumps)
     prob      = DiscreteProblem([A0,0], (0.0,tf))
-    jump_prob = JumpProblem(prob, method, jset; save_positions=(false,false))
+    jump_prob = JumpProblem(prob, method, jset; save_positions=(false,false), namedpars...)
 
     jump_prob
 end
@@ -118,7 +121,7 @@ function A_to_B_hybrid(N, method)
     majumps   = MassActionJump(rates[1:switchidx] , reactstoch, netstoch)
     jset      = JumpSet((), jumps, nothing, majumps)
     prob      = DiscreteProblem([A0,0], (0.0,tf))
-    jump_prob = JumpProblem(prob, method, jset; save_positions=(false,false))
+    jump_prob = JumpProblem(prob, method, jset; save_positions=(false,false), namedpars...)
 
     jump_prob
 end
@@ -151,7 +154,7 @@ function A_to_B_hybrid_nojset(N, method)
     majumps   = MassActionJump(rates[1:switchidx] , reactstoch, netstoch)
     jumps     = (constjumps...,majumps)
     prob      = DiscreteProblem([A0,0], (0.0,tf))
-    jump_prob = JumpProblem(prob, method, jumps...; save_positions=(false,false))
+    jump_prob = JumpProblem(prob, method, jumps...; save_positions=(false,false), namedpars...)
 
     jump_prob
 end
@@ -181,7 +184,7 @@ function A_to_B_hybrid_vecs(N, method)
      end
     jset      = JumpSet((), jumpvec, nothing, majumps)
     prob      = DiscreteProblem([A0,0], (0.0,tf))
-    jump_prob = JumpProblem(prob, method, jset; save_positions=(false,false))
+    jump_prob = JumpProblem(prob, method, jset; save_positions=(false,false), namedpars...)
 
     jump_prob
 end
@@ -210,7 +213,7 @@ function A_to_B_hybrid_vecs_scalars(N, method)
      end
     jset      = JumpSet((), jumpvec, nothing, majumps)
     prob      = DiscreteProblem([A0,0], (0.0,tf))
-    jump_prob = JumpProblem(prob, method, jset; save_positions=(false,false))
+    jump_prob = JumpProblem(prob, method, jset; save_positions=(false,false), namedpars...)
 
     jump_prob
 end
@@ -241,7 +244,7 @@ function A_to_B_hybrid_tups_scalars(N, method)
 
     jumps     = ((maj for maj in majumpsv)..., (jump for jump in jumpvec)...)
     prob      = DiscreteProblem([A0,0], (0.0,tf))
-    jump_prob = JumpProblem(prob, method, jumps...; save_positions=(false,false))
+    jump_prob = JumpProblem(prob, method, jumps...; save_positions=(false,false), namedpars...)
 
     jump_prob
 end
@@ -272,7 +275,7 @@ function A_to_B_hybrid_tups(N, method)
     jumps    = ((jump for jump in jumpvec)...,)
     jset      = JumpSet((), jumps, nothing, majumps)
     prob      = DiscreteProblem([A0,0], (0.0,tf))
-    jump_prob = JumpProblem(prob, method, jset; save_positions=(false,false))
+    jump_prob = JumpProblem(prob, method, jset; save_positions=(false,false), namedpars...)
 
     jump_prob
 end


### PR DESCRIPTION
See Marchetti, Priami and Thanh - Simulation Algorithms for Computational Systems Biology, for the version I've implemented. Some notes (more for myself):

1. Requires some new functionality (maps from species to dependent jumps, and jumps to dependent species). This has to be passed in as kwargs to the JumpProblem. I'll shortly submit a DiffEqBiological PR that will handle this for systems generated as a reaction_networks. 
2. I'm not seeing performance comparable to what the authors claim on simple examples (of course, the main benefit should be on larger systems than we currently test against). For example, on their own gene network test, which is in the problem library, I get comparable performance to `Direct` (vs a 25% speed-up they observe). Profiling shows that my implementation is slowed primarily by evaluating the mass action reaction rates, and by random number sampling in `generate_jumps!`. Changing the default random number generator can improve performance, but still does not reproduce their relative timings.
3. I'm generating the needed Erlang random variate as a sum of exponentials, in turn generated with `randexp`. An alternative is to use inverse transform sampling, taking the log of a product of uniform random numbers. This was generally slower in my testing.
4. All jump rate functions must be monotone with respect to populations. It is assumed mass action functions are monotone non-decreasing, but constant rate jumps are only assumed monotone.
5. `execute_jumps!` is doing redundant work, as rate bounds are recalculated more than once each for each event (they are recalculated for each species that has gone outside its bracketing interval). This could be fixed by saving a `Set` of marked jumps that need to have their bracketing interval recalculated, then going through them after updating all species. It's not clear if this will actually make a noticeable speed difference for typical networks where only a few species are updated.

Overall, it may just be that our `Direct` implementation is really good for small systems and beats the one by Marchetti et al. Looking at some larger networks would be good to confirm we are still seeing the expected speed-up on large systems.

