### PR TITLE
Changes in pois_rand

### DIFF
--- a/src/simple_regular_solve.jl
+++ b/src/simple_regular_solve.jl
@@ -38,7 +38,7 @@ function DiffEqBase.solve(jump_prob::JumpProblem,alg::SimpleTauLeaping;
       tprev = t[i-1]
       rate(rate_cache,uprev,p,tprev)
       rate_cache .*= dt
-      counts .= pois_rand.(rate_cache,(rng,))
+      counts .= pois_rand.(Ref(rng), rate_cache)
       !rj.constant_c && c(dc,uprev,p,tprev,mark)
       mul!(update,dc,counts)
       u[i] = uprev .+ update

--- a/src/simple_regular_solve.jl
+++ b/src/simple_regular_solve.jl
@@ -38,7 +38,7 @@ function DiffEqBase.solve(jump_prob::JumpProblem,alg::SimpleTauLeaping;
       tprev = t[i-1]
       rate(rate_cache,uprev,p,tprev)
       rate_cache .*= dt
-      counts .= pois_rand.(Ref(rng), rate_cache)
+      counts .= pois_rand.((rng,), rate_cache)
       !rj.constant_c && c(dc,uprev,p,tprev,mark)
       mul!(update,dc,counts)
       u[i] = uprev .+ update


### PR DESCRIPTION
This PR updates to the new order of arguments in `pois_rand` (https://github.com/JuliaDiffEq/PoissonRandom.jl/pull/4).

As mentioned in https://github.com/JuliaDiffEq/PoissonRandom.jl/pull/4#issuecomment-454691343, we probably should upper bound current versions of DiffEqJump and then add a lower bound to a new release of PoissonRandom here?