### PR TITLE
get_num_majumps returns zero when passed Nothing

### DIFF
--- a/src/jumps.jl
+++ b/src/jumps.jl
@@ -68,7 +68,7 @@ end
 MassActionJump(usr::T, rs::S, ns::U; scale_rates = true) where {T,S,U} = MassActionJump{T,S,U}(usr, rs, ns, scale_rates)
 
 @inline get_num_majumps(maj::MassActionJump) = length(maj.scaled_rates)
-
+@inline get_num_majumps(maj::Nothing) = 0
 
 struct JumpSet{T1,T2,T3,T4} <: AbstractJump
   variable_jumps::T1


### PR DESCRIPTION
Realized DiffEqBiological is calling this when there are no MassActionJumps (and hence passing nothing).