### PR TITLE
Fix hybrid Jump/DDE and Jump/DAE problems

### DIFF
--- a/src/problem.jl
+++ b/src/problem.jl
@@ -97,7 +97,9 @@ function extend_problem(prob::DiffEqBase.AbstractDAEProblem,jumps)
     update_jumps!(du,u,t,length(u.u),jumps.variable_jumps...)
   end
   u0 = ExtendedJumpArray(prob.u0,[-randexp() for i in 1:length(jumps.variable_jumps)])
-  DAEProblem(jump_f,prob.h,u0,prob.lags,prob.tspan)
+  DAEProblem(jump_f,du0,u0,tspan,prob.p,
+    callback=prob.callback,
+    differential_vars=prob.differential_vars)
 end
 
 function build_variable_callback(cb,idx,jump,jumps...)

--- a/src/problem.jl
+++ b/src/problem.jl
@@ -83,7 +83,11 @@ function extend_problem(prob::DiffEqBase.AbstractDDEProblem,jumps)
     update_jumps!(du,u,p,t,length(u.u),jumps.variable_jumps...)
   end
   u0 = ExtendedJumpArray(prob.u0,[-randexp() for i in 1:length(jumps.variable_jumps)])
-  DDEProblem(jump_f,prob.h,u0,prob.lags,prob.tspan,prob.p)
+  DDEProblem(jump_f,u0,prob.h,prob.tspan,prob.p,
+    constant_lags=prob.constant_lags,
+    dependent_lags=prob.dependent_lags,
+    callback=prob.callback,
+    neutral=prob.neutral)
 end
 
 # Not sure if the DAE one is correct: Should be a residual of sorts

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -24,7 +24,14 @@ function DiffEqBase.__init(
     jump_prob.prob.u0.jump_u .*= -1
   end
 
-  integrator = init(jump_prob.prob,alg,timeseries,ts,ks,recompile;
-                    callback=CallbackSet(callback,jump_prob.jump_callback),
-                    kwargs...)
+  # DDEProblems do not have a recompile_flag argument
+  if jump_prob.prob isa DiffEqBase.AbstractDDEProblem
+    integrator = init(jump_prob.prob,alg,timeseries,ts,ks;
+                      callback=CallbackSet(callback,jump_prob.jump_callback),
+                      kwargs...)
+  else
+    integrator = init(jump_prob.prob,alg,timeseries,ts,ks,recompile;
+                      callback=CallbackSet(callback,jump_prob.jump_callback),
+                      kwargs...)
+  end
 end


### PR DESCRIPTION
This should address #71. The issue is due to (i) typos in `extend_problem` and (ii) `DDEProblem` not using `recompile_flag` in its `__init` function.

Is this an appropriate place to add tests that catch breaking changes to these hybrid problems? I don't have the expertise to make sure the DDE and DAE problems are solved correctly, but we can at least detect when something goes wrong.