### PR TITLE
removed VariableRateJumps from VR_DirectEventCache

### DIFF
--- a/src/variable_rate.jl
+++ b/src/variable_rate.jl
@@ -360,9 +360,7 @@ function total_variable_rate(cache::VR_DirectEventCache{T, RNG, F1, F2}, u, p, t
     cum_rate_sum = cache.cum_rate_sum
     rate_funcs = cache.rate_funcs
 
-    cumsum_rates!(cum_rate_sum, u, p, t, rate_funcs)
-
-    @inbounds sum_rate = cum_rate_sum[end]
+    sum_rate = cumsum_rates!(cum_rate_sum, u, p, t, rate_funcs)
     return sum_rate
 end
 


### PR DESCRIPTION
This PR removes VariableRateJumps from Cache instead it sets rate and affect tuple

## Checklist

- [X] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [X] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
