### PR TITLE
Bug fixed in vr_agg

### DIFF
--- a/src/variable_rate.jl
+++ b/src/variable_rate.jl
@@ -354,7 +354,7 @@ end
 
 
 # Merge callback parameters across all jumps for VR_Direct
-function build_variable_integcallback(cache::VR_DirectEventCache, jumps::Tuple)
+function build_variable_integcallback(cache::VR_DirectEventCache, jumps)
     save_positions = (false, false)
     abstol = jumps[1].abstol
     reltol = jumps[1].reltol


### PR DESCRIPTION
jumps can be of any types like vector, tuple, etc...

Came across this issue while benchmarking

## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
