### PR TITLE
fix tau leaping doc example

### DIFF
--- a/docs/src/tutorials/discrete_stochastic_example.md
+++ b/docs/src/tutorials/discrete_stochastic_example.md
@@ -935,15 +935,15 @@ From there we build a `JumpProblem`
 ```@example tut2
 u₀ = [1000.0, 50.0, 0.0]
 prob = DiscreteProblem(u₀, tspan, p)
-jump_prob = JumpProblem(prob, Direct(), rj)
+jump_prob = JumpProblem(prob, PureLeaping(), rj)
 ```
-
+We pass the `PureLeaping` aggregator to indicate we will use a τ-leaping algorithm to simulate the process.
 Note that when a `JumpProblem` has a `RegularJump`, τ-leaping algorithms are
 required for simulating it. This is detailed on the [jump solvers page](@ref
-jump_solve). One such algorithm is `TauLeaping` from StochasticDiffEq.jl, which
+jump_solve). One such algorithm is `SimpleTauLeaping`, which
 we use as follows:
 
 ```@example tut2
-sol = solve(jump_prob, TauLeaping(); dt = 0.001)
+sol = solve(jump_prob, SimpleTauLeaping(); dt = 0.001)
 plot(sol; label = ["S(t)" "I(t)" "R(t)"])
 ```


### PR DESCRIPTION
@ChrisRackauckas is tau-leaping working in StochasticDiffEq currently? Seems like I get errors when I try to use it. For the doc example I get:
```
julia> sol = solve(jump_iipprob, TauLeaping())
ERROR: Default algorithm choices require DifferentialEquations.jl.
Please specify an algorithm (e.g., `solve(prob, Tsit5())` or
`init(prob, Tsit5())` for an ODE) or import DifferentialEquations
directly.

You can find the list of available solvers at <https://docs.sciml.ai/DiffEqDocs/stable/solvers/ode_solve>
and its associated pages.

Stacktrace:
  [1] __init(::DiscreteProblem{…}, ::Nothing, ::Vararg{…}; default_set::Bool, second_time::Bool, kwargs::@Kwargs{…})
    @ DiffEqBase ~/.julia/packages/DiffEqBase/dqv41/src/solve.jl:912
  [2] __init(prob::DiscreteProblem{…}, args::TauLeaping; default_set::Bool, second_time::Bool, kwargs::@Kwargs{…})
    @ DiffEqBase ~/.julia/packages/DiffEqBase/dqv41/src/solve.jl:917
  [3] init_call(_prob::DiscreteProblem{…}, args::TauLeaping; merge_callbacks::Bool, kwargshandle::Nothing, kwargs::@Kwargs{…})
    @ DiffEqBase ~/.julia/packages/DiffEqBase/dqv41/src/solve.jl:37
  [4] init_up(prob::DiscreteProblem{…}, sensealg::Nothing, u0::Vector{…}, p::SciMLBase.NullParameters, args::TauLeaping; kwargs::@Kwargs{…})
    @ DiffEqBase ~/.julia/packages/DiffEqBase/dqv41/src/solve.jl:79
  [5] init(prob::DiscreteProblem{…}, args::TauLeaping; sensealg::Nothing, u0::Nothing, p::Nothing, kwargs::@Kwargs{…})
    @ DiffEqBase ~/.julia/packages/DiffEqBase/dqv41/src/solve.jl:51
  [6] __jump_init(_jump_prob::JumpProblem{…}, alg::TauLeaping; callback::Nothing, seed::Nothing, alias_jump::Bool, kwargs::@Kwargs{})
    @ JumpProcesses ~/.julia/packages/JumpProcesses/Guu9D/src/solve.jl:53
  [7] __jump_init(_jump_prob::JumpProblem{…}, alg::TauLeaping)
    @ JumpProcesses ~/.julia/packages/JumpProcesses/Guu9D/src/solve.jl:34
  [8] __solve(jump_prob::JumpProblem{…}, alg::TauLeaping; kwargs::@Kwargs{})
    @ JumpProcesses ~/.julia/packages/JumpProcesses/Guu9D/src/solve.jl:13
  [9] __solve(jump_prob::JumpProblem{…}, alg::TauLeaping)
    @ JumpProcesses ~/.julia/packages/JumpProcesses/Guu9D/src/solve.jl:10
 [10] solve(prob::JumpProblem{…}, args::TauLeaping; kwargs::@Kwargs{})
    @ DiffEqBase ~/.julia/packages/DiffEqBase/dqv41/src/solve.jl:701
 [11] solve(prob::JumpProblem{…}, args::TauLeaping)
    @ DiffEqBase ~/.julia/packages/DiffEqBase/dqv41/src/solve.jl:700
 [12] top-level scope
    @ REPL[64]:1
Some type information was truncated. Use `show(err)` to see complete types.
```