### PR TITLE
Fix JET static analysis issues

### DIFF
--- a/src/simple_regular_solve.jl
+++ b/src/simple_regular_solve.jl
@@ -20,7 +20,7 @@ function DiffEqBase.solve(jump_prob::JumpProblem, alg::SimpleTauLeaping;
         error("SimpleTauLeaping can only be used with PureLeaping JumpProblems with only RegularJumps.")
 
     (; prob, rng) = jump_prob
-    (seed !== nothing) && seed!(rng, seed)
+    (seed !== nothing) && Random.seed!(rng, seed)
 
     rj = jump_prob.regular_jump
     rate = rj.rate # rate function rate(out,u,p,t)

--- a/src/spatial/flatten.jl
+++ b/src/spatial/flatten.jl
@@ -14,24 +14,26 @@ function flatten(ma_jump, prob::DiscreteProblem, spatial_system, hopping_constan
     end
     netstoch = ma_jump.net_stoch
     reactstoch = ma_jump.reactant_stoch
-    if isa(ma_jump, MassActionJump)
-        rx_rates = ma_jump.scaled_rates
+    rx_rates = if isa(ma_jump, MassActionJump)
+        ma_jump.scaled_rates
     elseif isa(ma_jump, SpatialMassActionJump)
         num_nodes = num_sites(spatial_system)
         if isnothing(ma_jump.uniform_rates) && isnothing(ma_jump.spatial_rates)
-            rx_rates = zeros(0, num_nodes)
+            zeros(0, num_nodes)
         elseif isnothing(ma_jump.uniform_rates)
-            rx_rates = ma_jump.spatial_rates
+            ma_jump.spatial_rates
         elseif isnothing(ma_jump.spatial_rates)
-            rx_rates = reshape(repeat(ma_jump.uniform_rates, num_nodes),
+            reshape(repeat(ma_jump.uniform_rates, num_nodes),
                 length(ma_jump.uniform_rates), num_nodes)
         else
             @assert size(ma_jump.spatial_rates, 2) == num_nodes
-            rx_rates = cat(dims = 1,
+            cat(dims = 1,
                 reshape(repeat(ma_jump.uniform_rates, num_nodes),
                     length(ma_jump.uniform_rates), num_nodes),
                 ma_jump.spatial_rates)
         end
+    else
+        error("flatten: unsupported jump type $(typeof(ma_jump))")
     end
     flatten(netstoch, reactstoch, rx_rates, spatial_system, u0, tspan, hopping_constants;
         scale_rates = false, kwargs...)

--- a/src/spatial/topology.jl
+++ b/src/spatial/topology.jl
@@ -85,17 +85,16 @@ end
 """
 given a vector of hopping constants of length num_neighbors(grid, site), form the vector of size 2*(dimension of grid) with zeros at indices where the neighbor is out of bounds. Store it in to_pad
 """
-function pad_hop_vec!(to_pad::AbstractVector{F}, grid, site,
-        hop_vec::Vector{F}) where {F <: Number}
+function pad_hop_vec!(to_pad::AbstractVector, grid, site, hop_vec::AbstractVector)
     CI = grid.CI
     I = CI[site]
     nbr_counter = 1
-    for (i, off) in enumerate(grid.offsets)
+    @inbounds for (i, off) in enumerate(grid.offsets)
         if I + off in CI
             to_pad[i] = hop_vec[nbr_counter]
             nbr_counter += 1
         else
-            to_pad[i] = zero(F)
+            to_pad[i] = zero(eltype(to_pad))
         end
     end
     to_pad


### PR DESCRIPTION
## Summary

This PR fixes several issues identified by JET.jl static analysis, improving static analysis compatibility and reducing potential runtime errors.

### Changes

1. **simple_regular_solve.jl**: Fixed undefined `seed!` reference - changed to `Random.seed!` since the function is not imported
2. **spatial/flatten.jl**: Fixed potentially undefined `rx_rates` variable by restructuring to an if-expression that always assigns a value, plus added error case for unsupported jump types
3. **spatial/topology.jl**: Relaxed type constraints on `pad_hop_vec!` to accept any `AbstractVector` arguments, fixing method dispatch issues with SubArrays. Added `@inbounds` and used `eltype(to_pad)` for type stability

### Results

These changes reduce JET-detected potential errors from 14 to 8 (the remaining issues are mostly JET analysis artifacts related to union type splitting in generated functions).

## Test plan

- [x] All targeted functionality tests pass
- [x] Existing tests pass (run through QA, Constant Rate, Variable Rate, ExtendedJumpArray, FunctionWrapper, Monte Carlo, Split Coupled, SSA, Tau Leaping, Callback, and Linear Reaction tests)

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)