### PR TITLE
Switch from JuliaFormatter to Runic.jl for code formatting

### DIFF
--- a/.JuliaFormatter.toml
+++ b/.JuliaFormatter.toml
@@ -1,3 +1,0 @@
-style = "sciml"
-format_markdown = true
-format_docstrings = true

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -1,13 +1,19 @@
-name: "Format Check"
+name: format-check
 
 on:
   push:
     branches:
       - 'master'
+      - 'main'
+      - 'release-'
     tags: '*'
   pull_request:
 
 jobs:
-  format-check:
-    name: "Format Check"
-    uses: "SciML/.github/.github/workflows/format-check.yml@v1"
+  runic:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: fredrikekre/runic-action@v1
+        with:
+          version: '1'

--- a/benchmarks/extended_jump_array.jl
+++ b/benchmarks/extended_jump_array.jl
@@ -10,11 +10,11 @@ benchmark_out = ExtendedJumpArray(zeros(500000), zeros(500000))
 benchmark_in = ExtendedJumpArray(rand(rng, 500000), rand(rng, 500000))
 
 function test_single_dot(out, array)
-    @inbounds @. out = array + 1.23 * array
+    return @inbounds @. out = array + 1.23 * array
 end
 
 function test_double_dot(out, array)
-    @inbounds @.. out = array + 1.23 * array
+    return @inbounds @.. out = array + 1.23 * array
 end
 
 println("Base-case normal broadcasting")

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -11,23 +11,33 @@ cp(joinpath(docpath, "Project.toml"), joinpath(assetpath, "Project.toml"), force
 
 include("pages.jl")
 
-mathengine = MathJax3(Dict(:loader => Dict("load" => ["[tex]/require", "[tex]/mathtools"]), :tex => Dict("inlineMath" => [["\$", "\$"], ["\\(", "\\)"]],
-        "packages" => [
-            "base",
-            "ams",
-            "autoload",
-            "mathtools",
-            "require"
-        ])))
+mathengine = MathJax3(
+    Dict(
+        :loader => Dict("load" => ["[tex]/require", "[tex]/mathtools"]), :tex => Dict(
+            "inlineMath" => [["\$", "\$"], ["\\(", "\\)"]],
+            "packages" => [
+                "base",
+                "ams",
+                "autoload",
+                "mathtools",
+                "require",
+            ]
+        )
+    )
+)
 
-makedocs(sitename = "JumpProcesses.jl", authors = "Chris Rackauckas", modules = [JumpProcesses],
+makedocs(
+    sitename = "JumpProcesses.jl", authors = "Chris Rackauckas", modules = [JumpProcesses],
     clean = true, doctest = false, linkcheck = true, warnonly = [:missing_docs],
-    format = Documenter.HTML(; assets = ["assets/favicon.ico"],
+    format = Documenter.HTML(;
+        assets = ["assets/favicon.ico"],
         canonical = "https://docs.sciml.ai/JumpProcesses/",
         prettyurls = (get(ENV, "CI", nothing) == "true"),
         mathengine,
         edit_link = "master",
-        repolink = "https://github.com/SciML/JumpProcesses.jl"),
-    pages = pages)
+        repolink = "https://github.com/SciML/JumpProcesses.jl"
+    ),
+    pages = pages
+)
 
 deploydocs(repo = "github.com/SciML/JumpProcesses.jl.git"; push_preview = true)

--- a/docs/pages.jl
+++ b/docs/pages.jl
@@ -1,14 +1,19 @@
 # Put in a separate page so it can be used by SciMLDocs.jl
 
-pages = ["index.md",
-    "Tutorials" => Any["tutorials/simple_poisson_process.md",
+pages = [
+    "index.md",
+    "Tutorials" => Any[
+        "tutorials/simple_poisson_process.md",
         "tutorials/discrete_stochastic_example.md",
         "tutorials/point_process_simulation.md",
         "tutorials/jump_diffusion.md",
-        "tutorials/spatial.md"],
+        "tutorials/spatial.md",
+    ],
     "Applications" => Any["applications/advanced_point_process.md"],
-    "Type Documentation" => Any["Jumps, JumpProblem, and Aggregators" => "jump_types.md",
-        "Jump solvers" => "jump_solve.md"],
+    "Type Documentation" => Any[
+        "Jumps, JumpProblem, and Aggregators" => "jump_types.md",
+        "Jump solvers" => "jump_solve.md",
+    ],
     "FAQ" => "faq.md",
-    "API" => "api.md"
+    "API" => "api.md",
 ]

--- a/ext/JumpProcessesKernelAbstractionsExt.jl
+++ b/ext/JumpProcessesKernelAbstractionsExt.jl
@@ -5,20 +5,24 @@ using KernelAbstractions, Adapt
 using StaticArrays
 using PoissonRandom, Random
 
-function SciMLBase.__solve(ensembleprob::SciMLBase.AbstractEnsembleProblem,
+function SciMLBase.__solve(
+        ensembleprob::SciMLBase.AbstractEnsembleProblem,
         alg::SimpleTauLeaping,
         ensemblealg::EnsembleGPUKernel;
         trajectories,
         seed = nothing,
         dt = error("dt is required for SimpleTauLeaping."),
-        kwargs...)
+        kwargs...
+    )
     if trajectories == 1
-        return SciMLBase.__solve(ensembleprob, alg, EnsembleSerial(); trajectories = 1,
-            seed, dt, kwargs...)
+        return SciMLBase.__solve(
+            ensembleprob, alg, EnsembleSerial(); trajectories = 1,
+            seed, dt, kwargs...
+        )
     end
 
     ensemblealg.backend === nothing ? backend = CPU() :
-    backend = ensemblealg.backend
+        backend = ensemblealg.backend
 
     jump_prob = ensembleprob.prob
 
@@ -31,36 +35,42 @@ function SciMLBase.__solve(ensembleprob::SciMLBase.AbstractEnsembleProblem,
 
     # Run vectorized solve
     ts,
-    us = vectorized_solve(
-        probs, jump_prob, SimpleTauLeaping(); backend, trajectories, seed, dt)
+        us = vectorized_solve(
+        probs, jump_prob, SimpleTauLeaping(); backend, trajectories, seed, dt
+    )
 
     # Convert to CPU for inspection
     _ts = Array(ts)
     _us = Array(us)
 
-    time = @elapsed sol = [begin
-                               ts = @view _ts[:, i]
-                               us = @view _us[:, :, i]
-                               sol_idx = findlast(x -> x != probs[i].prob.tspan[1], ts)
-                               if sol_idx === nothing
-                                   @error "No solution found" tspan=probs[i].tspan[1] ts
-                                   error("Batch solve failed")
-                               end
-                               @views ensembleprob.output_func(
-                                   SciMLBase.build_solution(probs[i].prob,
-                                       alg,
-                                       ts[1:sol_idx],
-                                       [us[j, :] for j in 1:sol_idx],
-                                       k = nothing,
-                                       stats = nothing,
-                                       calculate_error = false,
-                                       retcode = sol_idx !=
-                                                 length(ts) ?
-                                                 ReturnCode.Terminated :
-                                                 ReturnCode.Success),
-                                   i)[1]
-                           end
-                           for i in eachindex(probs)]
+    time = @elapsed sol = [
+        begin
+                ts = @view _ts[:, i]
+                us = @view _us[:, :, i]
+                sol_idx = findlast(x -> x != probs[i].prob.tspan[1], ts)
+                if sol_idx === nothing
+                    @error "No solution found" tspan = probs[i].tspan[1] ts
+                    error("Batch solve failed")
+            end
+                @views ensembleprob.output_func(
+                    SciMLBase.build_solution(
+                        probs[i].prob,
+                        alg,
+                        ts[1:sol_idx],
+                        [us[j, :] for j in 1:sol_idx],
+                        k = nothing,
+                        stats = nothing,
+                        calculate_error = false,
+                        retcode = sol_idx !=
+                        length(ts) ?
+                        ReturnCode.Terminated :
+                        ReturnCode.Success
+                    ),
+                    i
+                )[1]
+            end
+            for i in eachindex(probs)
+    ]
     return SciMLBase.EnsembleSolution(sol, time, true)
 end
 
@@ -82,7 +92,8 @@ end
 @kernel function simple_tau_leaping_kernel(
         @Const(probs_data), _us, _ts, dt, @Const(rj_data),
         current_u_buf, rate_cache_buf, counts_buf, local_dc_buf,
-        seed::UInt64)
+        seed::UInt64
+    )
     i = @index(Global, Linear)
 
     # Get thread-local buffers
@@ -114,7 +125,7 @@ end
 
     # Get input/output arrays
     ts_view = @inbounds view(_ts, :, i)
-    us_view = @inbounds view(_us,:,:,i)
+    us_view = @inbounds view(_us, :, :, i)
 
     # Initialize first time step and state
     @inbounds ts_view[1] = tspan[1]
@@ -124,7 +135,7 @@ end
 
     # Main loop
     for j in 2:n
-        tprev = tspan[1] + (j-2) * dt
+        tprev = tspan[1] + (j - 2) * dt
 
         # Compute rates and scale by dt
         rate(rate_cache, current_u, p, tprev)
@@ -143,20 +154,24 @@ end
         @inbounds for k in 1:state_dim
             us_view[j, k] = current_u[k]
         end
-        @inbounds ts_view[j] = tspan[1] + (j-1) * dt
+        @inbounds ts_view[j] = tspan[1] + (j - 1) * dt
     end
 end
 
 # Vectorized solve function
-function vectorized_solve(probs, prob::JumpProblem, alg::SimpleTauLeaping;
-        backend, trajectories, seed, dt, kwargs...)
+function vectorized_solve(
+        probs, prob::JumpProblem, alg::SimpleTauLeaping;
+        backend, trajectories, seed, dt, kwargs...
+    )
     # Extract common jump data
     rj = prob.regular_jump
     rj_data = JumpData(rj.rate, rj.c, rj.numjumps)
 
     # Extract trajectory-specific data without static typing
-    probs_data = [TrajectoryData(SA{eltype(p.prob.u0)}[p.prob.u0...], p.prob.p, p.prob.tspan)
-                  for p in probs]
+    probs_data = [
+        TrajectoryData(SA{eltype(p.prob.u0)}[p.prob.u0...], p.prob.p, p.prob.tspan)
+            for p in probs
+    ]
 
     # Adapt to GPU
     probs_data_gpu = adapt(backend, probs_data)
@@ -197,13 +212,15 @@ function vectorized_solve(probs, prob::JumpProblem, alg::SimpleTauLeaping;
     KernelAbstractions.synchronize(backend)
 
     # Seed for Poisson sampling
-    seed = seed === nothing ? UInt64(12345) : UInt64(seed);
+    seed = seed === nothing ? UInt64(12345) : UInt64(seed)
 
     # Launch main kernel
     kernel = simple_tau_leaping_kernel(backend)
-    main_event = kernel(probs_data_gpu, us, ts, dt, rj_data_gpu,
+    main_event = kernel(
+        probs_data_gpu, us, ts, dt, rj_data_gpu,
         current_u_buf, rate_cache_buf, counts_buf, local_dc_buf, seed;
-        ndrange = n_trajectories)
+        ndrange = n_trajectories
+    )
     KernelAbstractions.synchronize(backend)
 
     return ts, us

--- a/src/JumpProcesses.jl
+++ b/src/JumpProcesses.jl
@@ -33,10 +33,10 @@ import SymbolicIndexingInterface as SII
 
 # Import additional types and functions from DiffEqBase and SciMLBase
 using DiffEqBase: DiffEqBase, CallbackSet, ContinuousCallback, DAEFunction,
-                  DDEFunction, DiscreteProblem, ODEFunction, ODEProblem,
-                  ODESolution, ReturnCode, SDEFunction, SDEProblem, add_tstop!,
-                  deleteat!, isinplace, remake, savevalues!, step!,
-                  u_modified!
+    DDEFunction, DiscreteProblem, ODEFunction, ODEProblem,
+    ODESolution, ReturnCode, SDEFunction, SDEProblem, add_tstop!,
+    deleteat!, isinplace, remake, savevalues!, step!,
+    u_modified!
 using SciMLBase: SciMLBase, DEIntegrator
 
 abstract type AbstractJump end
@@ -44,7 +44,7 @@ abstract type AbstractMassActionJump <: AbstractJump end
 abstract type AbstractAggregatorAlgorithm end
 abstract type AbstractJumpAggregator end
 abstract type AbstractSSAIntegrator{Alg, IIP, U, T} <:
-              DEIntegrator{Alg, IIP, U, T} end
+DEIntegrator{Alg, IIP, U, T} end
 
 const DEFAULT_RNG = Random.default_rng()
 
@@ -126,7 +126,7 @@ export init, solve, solve!
 include("SSA_stepper.jl")
 export SSAStepper
 
-# leaping: 
+# leaping:
 include("simple_regular_solve.jl")
 export SimpleTauLeaping, EnsembleGPUKernel
 

--- a/src/aggregators/aggregated_api.jl
+++ b/src/aggregators/aggregated_api.jl
@@ -10,47 +10,63 @@ Notes
     MassActionJump that was built from the parameter vector. If the parameter
     vector is unchanged, this can safely be set to false to improve performance.
 """
-function reset_aggregated_jumps!(integrator, uprev = nothing; update_jump_params = true,
-        kwargs...)
-    reset_aggregated_jumps!(integrator, uprev, integrator.opts.callback,
-        update_jump_params = update_jump_params, kwargs...)
-    nothing
+function reset_aggregated_jumps!(
+        integrator, uprev = nothing; update_jump_params = true,
+        kwargs...
+    )
+    reset_aggregated_jumps!(
+        integrator, uprev, integrator.opts.callback,
+        update_jump_params = update_jump_params, kwargs...
+    )
+    return nothing
 end
 
-function reset_aggregated_jumps!(integrator, uprev, callback::Nothing;
-        update_jump_params = true, kwargs...)
-    nothing
+function reset_aggregated_jumps!(
+        integrator, uprev, callback::Nothing;
+        update_jump_params = true, kwargs...
+    )
+    return nothing
 end
 
-function reset_aggregated_jumps!(integrator, uprev, callback::CallbackSet;
-        update_jump_params = true, kwargs...)
+function reset_aggregated_jumps!(
+        integrator, uprev, callback::CallbackSet;
+        update_jump_params = true, kwargs...
+    )
     if !isempty(callback.discrete_callbacks)
-        reset_aggregated_jumps!(integrator, uprev, callback.discrete_callbacks...,
-            update_jump_params = update_jump_params, kwargs...)
+        reset_aggregated_jumps!(
+            integrator, uprev, callback.discrete_callbacks...,
+            update_jump_params = update_jump_params, kwargs...
+        )
     end
-    nothing
+    return nothing
 end
 
-function reset_aggregated_jumps!(integrator, uprev, cb::DiscreteCallback, cbs...;
-        update_jump_params = true, kwargs...)
+function reset_aggregated_jumps!(
+        integrator, uprev, cb::DiscreteCallback, cbs...;
+        update_jump_params = true, kwargs...
+    )
     if cb.condition isa AbstractSSAJumpAggregator
         maj = cb.condition.ma_jumps
         update_jump_params && using_params(maj) &&
             update_parameters!(cb.condition.ma_jumps, integrator.p; kwargs...)
         cb.condition(cb, integrator.u, integrator.t, integrator)
     end
-    reset_aggregated_jumps!(integrator, uprev, cbs...;
-        update_jump_params = update_jump_params, kwargs...)
-    nothing
+    reset_aggregated_jumps!(
+        integrator, uprev, cbs...;
+        update_jump_params = update_jump_params, kwargs...
+    )
+    return nothing
 end
 
-function reset_aggregated_jumps!(integrator, uprev, cb::DiscreteCallback;
-        update_jump_params = true, kwargs...)
+function reset_aggregated_jumps!(
+        integrator, uprev, cb::DiscreteCallback;
+        update_jump_params = true, kwargs...
+    )
     if cb.condition isa AbstractSSAJumpAggregator
         maj = cb.condition.ma_jumps
         update_jump_params && using_params(maj) &&
             update_parameters!(cb.condition.ma_jumps, integrator.p; kwargs...)
         cb.condition(cb, integrator.u, integrator.t, integrator)
     end
-    nothing
+    return nothing
 end

--- a/src/aggregators/aggregators.jl
+++ b/src/aggregators/aggregators.jl
@@ -172,8 +172,10 @@ algorithm with optimal binning,  Journal of Chemical Physics 143, 074108
 """
 struct DirectCRDirect <: AbstractAggregatorAlgorithm end
 
-const JUMP_AGGREGATORS = (Direct(), DirectFW(), DirectCR(), SortingDirect(), RSSA(), FRM(),
-    FRMFW(), NRM(), RSSACR(), RDirect(), Coevolve(), CCNRM())
+const JUMP_AGGREGATORS = (
+    Direct(), DirectFW(), DirectCR(), SortingDirect(), RSSA(), FRM(),
+    FRMFW(), NRM(), RSSACR(), RDirect(), Coevolve(), CCNRM(),
+)
 
 # For JumpProblem construction without an aggregator
 struct NullAggregator <: AbstractAggregatorAlgorithm end
@@ -204,9 +206,11 @@ is_spatial(aggregator::NSM) = true
 is_spatial(aggregator::DirectCRDirect) = true
 
 # return the fastest aggregator out of the available ones
-function select_aggregator(jumps::JumpSet; vartojumps_map = nothing,
+function select_aggregator(
+        jumps::JumpSet; vartojumps_map = nothing,
         jumptovars_map = nothing, dep_graph = nothing, spatial_system = nothing,
-        hopping_constants = nothing)
+        hopping_constants = nothing
+    )
 
     # detect if a spatial SSA should be used
     !isnothing(spatial_system) && !isnothing(hopping_constants) && return DirectCRDirect

--- a/src/aggregators/bracketing.jl
+++ b/src/aggregators/bracketing.jl
@@ -26,7 +26,7 @@ BracketData{T1, T2}() where {T1, T2} = BracketData(T1(0.1), T2(25), T2(4))
 @inline getΔu(bd::BracketData{T1, T2}, i) where {T1, T2 <: Number} = bd.Δu
 
 @inline function delta_bracket(u::Integer, δ)
-    (trunc(typeof(u), (one(δ) - δ) * u), trunc(typeof(u), (one(δ) + δ) * u))
+    return (trunc(typeof(u), (one(δ) - δ) * u), trunc(typeof(u), (one(δ) + δ) * u))
 end
 
 @inline delta_bracket(u, δ) = ((one(δ) - δ) * u), ((one(δ) + δ) * u)
@@ -48,7 +48,7 @@ end
 
 # Get propensity brackets of massaction jump k.
 @inline function get_majump_brackets(ulow, uhigh, k, majumps)
-    evalrxrate(ulow, k, majumps), evalrxrate(uhigh, k, majumps)
+    return evalrxrate(ulow, k, majumps), evalrxrate(uhigh, k, majumps)
 end
 
 # for constant rate jumps we must check the ordering of the bracket values
@@ -68,8 +68,10 @@ get brackets for the rate of reaction rx by first checking if the reaction is a 
     if rx <= num_majumps
         return get_majump_brackets(p.ulow, p.uhigh, rx, ma_jumps)
     else
-        @inbounds return get_cjump_brackets(p.ulow, p.uhigh, p.rates[rx - num_majumps],
-            params, t)
+        @inbounds return get_cjump_brackets(
+            p.ulow, p.uhigh, p.rates[rx - num_majumps],
+            params, t
+        )
     end
 end
 
@@ -79,7 +81,7 @@ end
     @inbounds for (i, uval) in enumerate(u)
         ulow[i], uhigh[i] = get_spec_brackets(p.bracket_data, i, uval)
     end
-    nothing
+    return nothing
 end
 
 @inline function update_u_brackets!(p::AbstractSSAJumpAggregator, u::SVector)
@@ -88,7 +90,7 @@ end
         p.ulow = setindex(p.ulow, ulow, i)
         p.uhigh = setindex(p.uhigh, uhigh, i)
     end
-    nothing
+    return nothing
 end
 
 # Set up bracketing. The aggregator must have fields
@@ -117,5 +119,5 @@ function set_bracketing!(p::AbstractSSAJumpAggregator, u, params, t)
     end
     p.sum_rate = sum_rate
 
-    nothing
+    return nothing
 end

--- a/src/aggregators/frm.jl
+++ b/src/aggregators/frm.jl
@@ -1,5 +1,5 @@
 mutable struct FRMJumpAggregation{T, S, F1, F2, RNG} <:
-               AbstractSSAJumpAggregator{T, S, F1, F2, RNG}
+    AbstractSSAJumpAggregator{T, S, F1, F2, RNG}
     next_jump::Int
     prev_jump::Int
     next_jump_time::T
@@ -12,52 +12,62 @@ mutable struct FRMJumpAggregation{T, S, F1, F2, RNG} <:
     save_positions::Tuple{Bool, Bool}
     rng::RNG
 end
-function FRMJumpAggregation(nj::Int, njt::T, et::T, crs::Vector{T}, sr::T, maj::S, rs::F1,
+function FRMJumpAggregation(
+        nj::Int, njt::T, et::T, crs::Vector{T}, sr::T, maj::S, rs::F1,
         affs!::F2, sps::Tuple{Bool, Bool}, rng::RNG;
-        kwargs...) where {T, S, F1, F2, RNG}
+        kwargs...
+    ) where {T, S, F1, F2, RNG}
     affecttype = F2 <: Tuple ? F2 : Any
-    FRMJumpAggregation{T, S, F1, affecttype, RNG}(nj, nj, njt, et, crs, sr, maj, rs,
-        affs!, sps, rng)
+    return FRMJumpAggregation{T, S, F1, affecttype, RNG}(
+        nj, nj, njt, et, crs, sr, maj, rs,
+        affs!, sps, rng
+    )
 end
 
 ############################# Required Functions #############################
 
 # creating the JumpAggregation structure (tuple-based constant jumps)
-function aggregate(aggregator::FRM, u, p, t, end_time, constant_jumps,
-        ma_jumps, save_positions, rng; kwargs...)
+function aggregate(
+        aggregator::FRM, u, p, t, end_time, constant_jumps,
+        ma_jumps, save_positions, rng; kwargs...
+    )
 
     # handle constant jumps using tuples
     rates, affects! = get_jump_info_tuples(constant_jumps)
 
-    build_jump_aggregation(
+    return build_jump_aggregation(
         FRMJumpAggregation, u, p, t, end_time, ma_jumps, rates, affects!,
-        save_positions, rng; kwargs...)
+        save_positions, rng; kwargs...
+    )
 end
 
 # creating the JumpAggregation structure (function wrapper-based constant jumps)
-function aggregate(aggregator::FRMFW, u, p, t, end_time, constant_jumps,
-        ma_jumps, save_positions, rng; kwargs...)
+function aggregate(
+        aggregator::FRMFW, u, p, t, end_time, constant_jumps,
+        ma_jumps, save_positions, rng; kwargs...
+    )
 
     # handle constant jumps using function wrappers
     rates, affects! = get_jump_info_fwrappers(u, p, t, constant_jumps)
 
-    build_jump_aggregation(
+    return build_jump_aggregation(
         FRMJumpAggregation, u, p, t, end_time, ma_jumps, rates, affects!,
-        save_positions, rng; kwargs...)
+        save_positions, rng; kwargs...
+    )
 end
 
 # set up a new simulation and calculate the first jump / jump time
 function initialize!(p::FRMJumpAggregation, integrator, u, params, t)
     p.end_time = integrator.sol.prob.tspan[2]
     generate_jumps!(p, integrator, u, params, t)
-    nothing
+    return nothing
 end
 
 # execute one jump, changing the system state
 @inline function execute_jumps!(p::FRMJumpAggregation, integrator, u, params, t, affects!)
     # execute jump
     update_state!(p, integrator, u, affects!)
-    nothing
+    return nothing
 end
 
 # calculate the next jump / jump time
@@ -73,7 +83,7 @@ function generate_jumps!(p::FRMJumpAggregation, integrator, u, params, t)
         p.next_jump = nextcrj
         p.next_jump_time = t + ttncrj
     end
-    nothing
+    return nothing
 end
 
 ######################## SSA specific helper routines ########################
@@ -91,12 +101,14 @@ function next_ma_jump(p::FRMJumpAggregation, u, params, t)
             nextrx = i
         end
     end
-    nextrx, ttnj
+    return nextrx, ttnj
 end
 
 # tuple-based constant jumps
-function next_constant_rate_jump(p::FRMJumpAggregation{T, S, F1, F2, RNG}, u, params,
-        t) where {T, S, F1 <: Tuple, F2 <: Tuple, RNG}
+function next_constant_rate_jump(
+        p::FRMJumpAggregation{T, S, F1, F2, RNG}, u, params,
+        t
+    ) where {T, S, F1 <: Tuple, F2 <: Tuple, RNG}
     ttnj = typemax(typeof(t))
     nextrx = zero(Int)
     if !isempty(p.rates)
@@ -110,12 +122,14 @@ function next_constant_rate_jump(p::FRMJumpAggregation{T, S, F1, F2, RNG}, u, pa
             end
         end
     end
-    nextrx, ttnj
+    return nextrx, ttnj
 end
 
 # function wrapper-based constant jumps
-function next_constant_rate_jump(p::FRMJumpAggregation{T, S, F1}, u, params,
-        t) where {T, S, F1 <: AbstractArray}
+function next_constant_rate_jump(
+        p::FRMJumpAggregation{T, S, F1}, u, params,
+        t
+    ) where {T, S, F1 <: AbstractArray}
     ttnj = typemax(typeof(t))
     nextrx = zero(Int)
     if !isempty(p.rates)
@@ -130,5 +144,5 @@ function next_constant_rate_jump(p::FRMJumpAggregation{T, S, F1}, u, params,
             idx += 1
         end
     end
-    nextrx, ttnj
+    return nextrx, ttnj
 end

--- a/src/aggregators/nrm.jl
+++ b/src/aggregators/nrm.jl
@@ -2,7 +2,7 @@
 # Gibson and Bruck, J. Phys. Chem. A, 104 (9), (2000)
 
 mutable struct NRMJumpAggregation{T, S, F1, F2, RNG, DEPGR, PQ} <:
-               AbstractSSAJumpAggregator{T, S, F1, F2, RNG}
+    AbstractSSAJumpAggregator{T, S, F1, F2, RNG}
     next_jump::Int
     prev_jump::Int
     next_jump_time::T
@@ -18,10 +18,12 @@ mutable struct NRMJumpAggregation{T, S, F1, F2, RNG, DEPGR, PQ} <:
     pq::PQ
 end
 
-function NRMJumpAggregation(nj::Int, njt::T, et::T, crs::Vector{T}, sr::T,
+function NRMJumpAggregation(
+        nj::Int, njt::T, et::T, crs::Vector{T}, sr::T,
         maj::S, rs::F1, affs!::F2, sps::Tuple{Bool, Bool},
         rng::RNG; num_specs, dep_graph = nothing,
-        kwargs...) where {T, S, F1, F2, RNG}
+        kwargs...
+    ) where {T, S, F1, F2, RNG}
 
     # a dependency graph is needed and must be provided if there are constant rate jumps
     if dep_graph === nothing
@@ -40,23 +42,29 @@ function NRMJumpAggregation(nj::Int, njt::T, et::T, crs::Vector{T}, sr::T,
     pq = MutableBinaryMinHeap{T}()
 
     affecttype = F2 <: Tuple ? F2 : Any
-    NRMJumpAggregation{T, S, F1, affecttype, RNG, typeof(dg), typeof(pq)}(nj, nj, njt, et,
+    return NRMJumpAggregation{T, S, F1, affecttype, RNG, typeof(dg), typeof(pq)}(
+        nj, nj, njt, et,
         crs, sr, maj,
         rs, affs!, sps,
-        rng, dg, pq)
+        rng, dg, pq
+    )
 end
 
-+############################# Required Functions ##############################
++ ############################# Required Functions ##############################
 # creating the JumpAggregation structure (function wrapper-based constant jumps)
-function aggregate(aggregator::NRM, u, p, t, end_time, constant_jumps,
-        ma_jumps, save_positions, rng; kwargs...)
+function aggregate(
+        aggregator::NRM, u, p, t, end_time, constant_jumps,
+        ma_jumps, save_positions, rng; kwargs...
+    )
 
     # handle constant jumps using function wrappers
     rates, affects! = get_jump_info_fwrappers(u, p, t, constant_jumps)
 
-    build_jump_aggregation(NRMJumpAggregation, u, p, t, end_time, ma_jumps,
+    return build_jump_aggregation(
+        NRMJumpAggregation, u, p, t, end_time, ma_jumps,
         rates, affects!, save_positions, rng; num_specs = length(u),
-        kwargs...)
+        kwargs...
+    )
 end
 
 # set up a new simulation and calculate the first jump / jump time
@@ -64,7 +72,7 @@ function initialize!(p::NRMJumpAggregation, integrator, u, params, t)
     p.end_time = integrator.sol.prob.tspan[2]
     fill_rates_and_get_times!(p, u, params, t)
     generate_jumps!(p, integrator, u, params, t)
-    nothing
+    return nothing
 end
 
 # execute one jump, changing the system state
@@ -74,14 +82,14 @@ function execute_jumps!(p::NRMJumpAggregation, integrator, u, params, t, affects
 
     # update current jump rates and times
     update_dependent_rates!(p, u, params, t)
-    nothing
+    return nothing
 end
 
 # calculate the next jump / jump time
 # just the top of the priority queue
 function generate_jumps!(p::NRMJumpAggregation, integrator, u, params, t)
     p.next_jump_time, p.next_jump = top_with_handle(p.pq)
-    nothing
+    return nothing
 end
 
 ######################## SSA specific helper routines ########################
@@ -96,8 +104,10 @@ function update_dependent_rates!(p::NRMJumpAggregation, u, params, t)
         oldrate = cur_rates[rx]
 
         # update the jump rate
-        @inbounds cur_rates[rx] = calculate_jump_rate(ma_jumps, num_majumps, rates, u,
-            params, t, rx)
+        @inbounds cur_rates[rx] = calculate_jump_rate(
+            ma_jumps, num_majumps, rates, u,
+            params, t, rx
+        )
 
         # calculate new jump times for dependent jumps
         if rx != p.next_jump && oldrate > zero(oldrate)
@@ -114,7 +124,7 @@ function update_dependent_rates!(p::NRMJumpAggregation, u, params, t)
             end
         end
     end
-    nothing
+    return nothing
 end
 
 # reevaluate all rates, recalculate all jump times, and reinit the priority queue
@@ -140,5 +150,5 @@ function fill_rates_and_get_times!(p::NRMJumpAggregation, u, params, t)
 
     # setup a new indexed priority queue to storing rx times
     p.pq = MutableBinaryMinHeap(pqdata)
-    nothing
+    return nothing
 end

--- a/src/aggregators/sortingdirect.jl
+++ b/src/aggregators/sortingdirect.jl
@@ -3,7 +3,7 @@
 # Comp. Bio. and Chem., 30, pg. 39-49 (2006).
 
 mutable struct SortingDirectJumpAggregation{T, S, F1, F2, RNG, DEPGR} <:
-               AbstractSSAJumpAggregator{T, S, F1, F2, RNG}
+    AbstractSSAJumpAggregator{T, S, F1, F2, RNG}
     next_jump::Int
     prev_jump::Int
     next_jump_time::T
@@ -20,10 +20,12 @@ mutable struct SortingDirectJumpAggregation{T, S, F1, F2, RNG, DEPGR} <:
     jump_search_idx::Int
 end
 
-function SortingDirectJumpAggregation(nj::Int, njt::T, et::T, crs::Vector{T}, sr::T,
+function SortingDirectJumpAggregation(
+        nj::Int, njt::T, et::T, crs::Vector{T}, sr::T,
         maj::S, rs::F1, affs!::F2, sps::Tuple{Bool, Bool},
         rng::RNG; num_specs, dep_graph = nothing,
-        kwargs...) where {T, S, F1, F2, RNG}
+        kwargs...
+    ) where {T, S, F1, F2, RNG}
 
     # a dependency graph is needed and must be provided if there are constant rate jumps
     if dep_graph === nothing
@@ -42,25 +44,31 @@ function SortingDirectJumpAggregation(nj::Int, njt::T, et::T, crs::Vector{T}, sr
     # map jump idx to idx in cur_rates
     jtoidx = collect(1:length(crs))
     affecttype = F2 <: Tuple ? F2 : Any
-    SortingDirectJumpAggregation{T, S, F1, affecttype, RNG, typeof(dg)}(nj, nj, njt, et,
+    return SortingDirectJumpAggregation{T, S, F1, affecttype, RNG, typeof(dg)}(
+        nj, nj, njt, et,
         crs, sr, maj, rs,
         affs!, sps, rng,
         dg, jtoidx,
-        zero(Int))
+        zero(Int)
+    )
 end
 
 ############################# Required Functions ##############################
 
 # creating the JumpAggregation structure (function wrapper-based constant jumps)
-function aggregate(aggregator::SortingDirect, u, p, t, end_time, constant_jumps,
-        ma_jumps, save_positions, rng; kwargs...)
+function aggregate(
+        aggregator::SortingDirect, u, p, t, end_time, constant_jumps,
+        ma_jumps, save_positions, rng; kwargs...
+    )
 
     # handle constant jumps using function wrappers
     rates, affects! = get_jump_info_fwrappers(u, p, t, constant_jumps)
 
-    build_jump_aggregation(SortingDirectJumpAggregation, u, p, t, end_time, ma_jumps,
+    return build_jump_aggregation(
+        SortingDirectJumpAggregation, u, p, t, end_time, ma_jumps,
         rates, affects!, save_positions, rng; num_specs = length(u),
-        kwargs...)
+        kwargs...
+    )
 end
 
 # set up a new simulation and calculate the first jump / jump time
@@ -68,7 +76,7 @@ function initialize!(p::SortingDirectJumpAggregation, integrator, u, params, t)
     p.end_time = integrator.sol.prob.tspan[2]
     fill_rates_and_sum!(p, u, params, t)
     generate_jumps!(p, integrator, u, params, t)
-    nothing
+    return nothing
 end
 
 # execute one jump, changing the system state
@@ -87,7 +95,7 @@ function execute_jumps!(p::SortingDirectJumpAggregation, integrator, u, params, 
 
     # update current jump rates
     update_dependent_rates!(p, u, params, t)
-    nothing
+    return nothing
 end
 
 # calculate the next jump / jump time
@@ -110,5 +118,5 @@ function generate_jumps!(p::SortingDirectJumpAggregation, integrator, u, params,
         @inbounds p.next_jump = jso[p.jump_search_idx]
     end
 
-    nothing
+    return nothing
 end

--- a/src/coupled_array.jl
+++ b/src/coupled_array.jl
@@ -7,7 +7,7 @@ end
 Base.length(A::CoupledArray) = length(A.u) + length(A.u_control)
 Base.size(A::CoupledArray) = (length(A),)
 @inline function Base.getindex(A::CoupledArray, i::Int)
-    if A.order == true
+    return if A.order == true
         i <= length(A.u) ? A.u[i] : A.u_control[i - length(A.u)]
     else
         i <= length(A.u) ? A.u_control[i] : A.u[i - length(A.u)]
@@ -15,17 +15,17 @@ Base.size(A::CoupledArray) = (length(A),)
 end
 
 @inline function Base.getindex(A::CoupledArray, I...)
-    A[CartesianIndices(A.u, I...)]
+    return A[CartesianIndices(A.u, I...)]
 end
 
 @inline function Base.getindex(A::CoupledArray, I::CartesianIndex{1})
-    A[I[1]]
+    return A[I[1]]
 end
 
 @inline Base.setindex!(A::CoupledArray, v, I...) = (A[CartesianIndices(A.u, I...)] = v)
 @inline Base.setindex!(A::CoupledArray, v, I::CartesianIndex{1}) = (A[I[1]] = v)
 @inline function Base.setindex!(A::CoupledArray, v, i::Int)
-    if A.order == true
+    return if A.order == true
         i <= length(A.u) ? (A.u[i] = v) : (A.u_control[i - length(A.u)] = v)
     else
         i <= length(A.u) ? (A.u_control[i] = v) : (A.u[i - length(A.u)] = v)
@@ -35,13 +35,13 @@ end
 Base.IndexStyle(::Type{<:CoupledArray}) = IndexLinear()
 Base.similar(A::CoupledArray) = CoupledArray(similar(A.u), similar(A.u_control), A.order)
 function Base.similar(A::CoupledArray, ::Type{S}) where {S}
-    CoupledArray(similar(A.u, S), similar(A.u_control, S), A.order)
+    return CoupledArray(similar(A.u, S), similar(A.u_control, S), A.order)
 end
 
 function recursivecopy!(dest::T, src::T) where {T <: CoupledArray}
     recursivecopy!(dest.u, src.u)
     recursivecopy!(dest.u_control, src.u_control)
-    dest.order = src.order
+    return dest.order = src.order
 end
 
 add_idxs1(::Type{T}, expr) where {T <: CoupledArray} = :($(expr).u)
@@ -53,7 +53,7 @@ add_idxs2(::Type{T}, expr) where {T <: CoupledArray} = :($(expr).u_control)
         broadcast!(f, A.u, $(exs1...))
         broadcast!(f, A.u_control, $(exs2...))
     end
-    res
+    return res
 end
 
 Base.show(io::IO, A::CoupledArray) = show(io, A.u)

--- a/src/coupling.jl
+++ b/src/coupling.jl
@@ -3,22 +3,28 @@ David F. Anderson, Masanori Koyama; An asymptotic relationship between coupling
 methods for stochastically modeled population processes. IMA J Numer Anal 2015;
 35 (4): 1757-1778. doi: 10.1093/imanum/dru044
 """
-function SplitCoupledJumpProblem(prob::DiffEqBase.AbstractJumpProblem,
+function SplitCoupledJumpProblem(
+        prob::DiffEqBase.AbstractJumpProblem,
         prob_control::DiffEqBase.AbstractJumpProblem,
         aggregator::AbstractAggregatorAlgorithm,
-        coupling_map::Vector{Tuple{Int, Int}}; kwargs...)
-    JumpProblem(cat_problems(prob.prob, prob_control.prob), aggregator,
-        build_split_jumps(prob, prob_control, coupling_map)...; kwargs...)
+        coupling_map::Vector{Tuple{Int, Int}}; kwargs...
+    )
+    return JumpProblem(
+        cat_problems(prob.prob, prob_control.prob), aggregator,
+        build_split_jumps(prob, prob_control, coupling_map)...; kwargs...
+    )
 end
 
 # make new problem by joining initial_data
 function cat_problems(prob::DiscreteProblem, prob_control::DiscreteProblem)
     u0_coupled = CoupledArray(prob.u0, prob_control.u0, true)
-    DiscreteProblem(u0_coupled, prob.tspan, prob.p)
+    return DiscreteProblem(u0_coupled, prob.tspan, prob.p)
 end
 
-function cat_problems(prob::DiffEqBase.AbstractODEProblem,
-        prob_control::DiffEqBase.AbstractODEProblem)
+function cat_problems(
+        prob::DiffEqBase.AbstractODEProblem,
+        prob_control::DiffEqBase.AbstractODEProblem
+    )
     l = length(prob.u0) # add l_c = length(prob_control.u0)
 
     _f = SciMLBase.unwrapped_f(prob.f)
@@ -26,10 +32,10 @@ function cat_problems(prob::DiffEqBase.AbstractODEProblem,
 
     new_f = function (du, u, p, t)
         _f(@view(du[1:l]), u.u, p, t)
-        _f_control(@view(du[(l + 1):(2 * l)]), u.u_control, p, t)
+        return _f_control(@view(du[(l + 1):(2 * l)]), u.u_control, p, t)
     end
     u0_coupled = CoupledArray(prob.u0, prob_control.u0, true)
-    ODEProblem(new_f, u0_coupled, prob.tspan, prob.p)
+    return ODEProblem(new_f, u0_coupled, prob.tspan, prob.p)
 end
 
 function cat_problems(prob::DiscreteProblem, prob_control::DiffEqBase.AbstractODEProblem)
@@ -43,29 +49,33 @@ function cat_problems(prob::DiscreteProblem, prob_control::DiffEqBase.AbstractOD
 
     new_f = function (du, u, p, t)
         _f(@view(du[1:l]), u.u, p, t)
-        _f_control(@view(du[(l + 1):(2 * l)]), u.u_control, p, t)
+        return _f_control(@view(du[(l + 1):(2 * l)]), u.u_control, p, t)
     end
     u0_coupled = CoupledArray(prob.u0, prob_control.u0, true)
-    ODEProblem(new_f, u0_coupled, prob.tspan, prob.p)
+    return ODEProblem(new_f, u0_coupled, prob.tspan, prob.p)
 end
 
-function cat_problems(prob::DiffEqBase.AbstractSDEProblem,
-        prob_control::DiffEqBase.AbstractSDEProblem)
+function cat_problems(
+        prob::DiffEqBase.AbstractSDEProblem,
+        prob_control::DiffEqBase.AbstractSDEProblem
+    )
     l = length(prob.u0)
     new_f = function (du, u, p, t)
         prob.f(@view(du[1:l]), u.u, p, t)
-        prob_control.f(@view(du[(l + 1):(2 * l)]), u.u_control, p, t)
+        return prob_control.f(@view(du[(l + 1):(2 * l)]), u.u_control, p, t)
     end
     new_g = function (du, u, p, t)
         prob.g(@view(du[1:l]), u.u, p, t)
-        prob_control.g(@view(du[(l + 1):(2 * l)]), u.u_control, p, t)
+        return prob_control.g(@view(du[(l + 1):(2 * l)]), u.u_control, p, t)
     end
     u0_coupled = CoupledArray(prob.u0, prob_control.u0, true)
-    SDEProblem(new_f, new_g, u0_coupled, prob.tspan, prob.p)
+    return SDEProblem(new_f, new_g, u0_coupled, prob.tspan, prob.p)
 end
 
-function cat_problems(prob::DiffEqBase.AbstractSDEProblem,
-        prob_control::DiffEqBase.AbstractODEProblem)
+function cat_problems(
+        prob::DiffEqBase.AbstractSDEProblem,
+        prob_control::DiffEqBase.AbstractODEProblem
+    )
     l = length(prob.u0)
 
     _f = SciMLBase.unwrapped_f(prob.f)
@@ -73,16 +83,17 @@ function cat_problems(prob::DiffEqBase.AbstractSDEProblem,
 
     new_f = function (du, u, p, t)
         _f(@view(du[1:l]), u.u, p, t)
-        _f_control(@view(du[(l + 1):(2 * l)]), u.u_control, p, t)
+        return _f_control(@view(du[(l + 1):(2 * l)]), u.u_control, p, t)
     end
     new_g = function (du, u, p, t)
         prob.g(@view(du[1:l]), u.u, p, t)
         for i in (l + 1):(2 * l)
             du[i] = 0.0
         end
+        return
     end
     u0_coupled = CoupledArray(prob.u0, prob_control.u0, true)
-    SDEProblem(new_f, new_g, u0_coupled, prob.tspan, prob.p)
+    return SDEProblem(new_f, new_g, u0_coupled, prob.tspan, prob.p)
 end
 
 function cat_problems(prob::DiffEqBase.AbstractSDEProblem, prob_control::DiscreteProblem)
@@ -92,33 +103,38 @@ function cat_problems(prob::DiffEqBase.AbstractSDEProblem, prob_control::Discret
     end
     new_f = function (du, u, p, t)
         prob.f(@view(du[1:l]), u.u, p, t)
-        prob_control.f(@view(du[(l + 1):(2 * l)]), u.u_control, p, t)
+        return prob_control.f(@view(du[(l + 1):(2 * l)]), u.u_control, p, t)
     end
     new_g = function (du, u, p, t)
         prob.g(@view(du[1:l]), u.u, p, t)
         for i in (l + 1):(2 * l)
             du[i] = 0.0
         end
+        return
     end
     u0_coupled = CoupledArray(prob.u0, prob_control.u0, true)
-    SDEProblem(new_f, new_g, u0_coupled, prob.tspan)
+    return SDEProblem(new_f, new_g, u0_coupled, prob.tspan)
 end
 
 function cat_problems(prob_control::DiffEqBase.AbstractODEProblem, prob::DiscreteProblem)
-    cat_problems(prob, prob_control)
+    return cat_problems(prob, prob_control)
 end
 function cat_problems(prob_control::DiscreteProblem, prob::DiffEqBase.AbstractSDEProblem)
-    cat_problems(prob, prob_control)
+    return cat_problems(prob, prob_control)
 end
-function cat_problems(prob_control::DiffEqBase.AbstractODEProblem,
-        prob::DiffEqBase.AbstractSDEProblem)
-    cat_problems(prob, prob_control)
+function cat_problems(
+        prob_control::DiffEqBase.AbstractODEProblem,
+        prob::DiffEqBase.AbstractSDEProblem
+    )
+    return cat_problems(prob, prob_control)
 end
 
 # this only depends on the jumps in prob, not prob.prob
-function build_split_jumps(prob::DiffEqBase.AbstractJumpProblem,
+function build_split_jumps(
+        prob::DiffEqBase.AbstractJumpProblem,
         prob_control::DiffEqBase.AbstractJumpProblem,
-        coupling_map::Vector{Tuple{Int, Int}})
+        coupling_map::Vector{Tuple{Int, Int}}
+    )
     num_jumps = length(prob.discrete_jump_aggregation.rates)
     num_jumps_control = length(prob_control.discrete_jump_aggregation.rates)
     jumps = []
@@ -137,7 +153,7 @@ function build_split_jumps(prob::DiffEqBase.AbstractJumpProblem,
         new_affect! = function (integrator)
             flip_u!(integrator.u)
             affect!(integrator)
-            flip_u!(integrator.u)
+            return flip_u!(integrator.u)
         end
         push!(jumps, ConstantRateJump(new_rate, new_affect!))
     end
@@ -152,24 +168,24 @@ function build_split_jumps(prob::DiffEqBase.AbstractJumpProblem,
             affect!(integrator)
             flip_u!(integrator.u)
             affect_control!(integrator)
-            flip_u!(integrator.u)
+            return flip_u!(integrator.u)
         end
         new_rate = (u, p, t) -> min(rate(u.u, p, t), rate_control(u.u_control, p, t))
         push!(jumps, ConstantRateJump(new_rate, new_affect!))
         # only prob
         new_affect! = affect!
         new_rate = (u, p, t) -> rate(u.u, p, t) -
-                  min(rate(u.u, p, t), rate_control(u.u_control, p, t))
+            min(rate(u.u, p, t), rate_control(u.u_control, p, t))
         push!(jumps, ConstantRateJump(new_rate, new_affect!))
         # only prob_control
         new_affect! = function (integrator)
             flip_u!(integrator.u)
             affect!(integrator)
-            flip_u!(integrator.u)
+            return flip_u!(integrator.u)
         end
         new_rate = (u, p, t) -> rate_control(u.u_control, p, t) -
-                  min(rate(u.u, p, t), rate_control(u.u_control, p, t))
+            min(rate(u.u, p, t), rate_control(u.u_control, p, t))
         push!(jumps, ConstantRateJump(new_rate, new_affect!))
     end
-    jumps
+    return jumps
 end

--- a/src/extended_jump_array.jl
+++ b/src/extended_jump_array.jl
@@ -58,7 +58,7 @@ sol = solve(jprob, Tsit5())
     operations should use `ueja.u.u` to obtain the aliased state object.
 """
 struct ExtendedJumpArray{T3 <: Number, T1, T <: AbstractArray{T3, T1}, T2} <:
-       AbstractArray{T3, 1}
+    AbstractArray{T3, 1}
     """The current state."""
     u::T
     """The current rate (i.e. hazard, intensity, or propensity) values for the `VariableRateJump`s."""
@@ -68,36 +68,38 @@ end
 Base.length(A::ExtendedJumpArray) = length(A.u) + length(A.jump_u)
 Base.size(A::ExtendedJumpArray) = (length(A),)
 @inline function Base.getindex(A::ExtendedJumpArray, i::Int)
-    i <= length(A.u) ? A.u[i] : A.jump_u[i - length(A.u)]
+    return i <= length(A.u) ? A.u[i] : A.jump_u[i - length(A.u)]
 end
 @inline function Base.getindex(A::ExtendedJumpArray, I::Int...)
-    prod(I) <= length(A.u) ? A.u[I...] : A.jump_u[prod(I) - length(A.u)]
+    return prod(I) <= length(A.u) ? A.u[I...] : A.jump_u[prod(I) - length(A.u)]
 end
 @inline function Base.getindex(A::ExtendedJumpArray, I::CartesianIndex{1})
-    A[I[1]]
+    return A[I[1]]
 end
 @inline Base.setindex!(A::ExtendedJumpArray, v, I...) = (A[CartesianIndices(A.u, I...)] = v)
 @inline Base.setindex!(A::ExtendedJumpArray, v, I::CartesianIndex{1}) = (A[I[1]] = v)
 @inline function Base.setindex!(A::ExtendedJumpArray, v, i::Int)
-    i <= length(A.u) ? (A.u[i] = v) : (A.jump_u[i - length(A.u)] = v)
+    return i <= length(A.u) ? (A.u[i] = v) : (A.jump_u[i - length(A.u)] = v)
 end
 
 Base.IndexStyle(::Type{<:ExtendedJumpArray}) = IndexLinear()
 Base.similar(A::ExtendedJumpArray) = ExtendedJumpArray(similar(A.u), similar(A.jump_u))
 function Base.similar(A::ExtendedJumpArray, ::Type{S}) where {S}
-    ExtendedJumpArray(similar(A.u, S), similar(A.jump_u, S))
+    return ExtendedJumpArray(similar(A.u, S), similar(A.jump_u, S))
 end
 Base.zero(A::ExtendedJumpArray) = fill!(similar(A), 0)
 
 # Required for non-diagonal noise
 function LinearAlgebra.mul!(c::ExtendedJumpArray, A::AbstractVecOrMat, u::AbstractVector)
-    mul!(c.u, A, u)
+    return mul!(c.u, A, u)
 end
 
 # Ignore axes
-function Base.similar(A::ExtendedJumpArray, ::Type{S},
-        axes::Tuple{Base.OneTo{Int}}) where {S}
-    ExtendedJumpArray(similar(A.u, S), similar(A.jump_u, S))
+function Base.similar(
+        A::ExtendedJumpArray, ::Type{S},
+        axes::Tuple{Base.OneTo{Int}}
+    ) where {S}
+    return ExtendedJumpArray(similar(A.u, S), similar(A.jump_u, S))
 end
 
 # plotting
@@ -105,21 +107,21 @@ SciMLBase.plottable_indices(u::ExtendedJumpArray) = SciMLBase.plottable_indices(
 
 # ODE norm to prevent type-unstable fallback
 @inline function DiffEqBase.ODE_DEFAULT_NORM(u::ExtendedJumpArray, t)
-    Base.FastMath.sqrt_fast(real(sum(abs2, u)) / max(length(u), 1))
+    return Base.FastMath.sqrt_fast(real(sum(abs2, u)) / max(length(u), 1))
 end
 
 # Stiff ODE solver
 function ArrayInterface.zeromatrix(A::ExtendedJumpArray)
     u = [vec(A.u); vec(A.jump_u)]
-    u .* u' .* false
+    return u .* u' .* false
 end
 function LinearAlgebra.ldiv!(A::LinearAlgebra.LU, b::ExtendedJumpArray)
-    LinearAlgebra.ldiv!(A, [vec(b.u); vec(b.jump_u)])
+    return LinearAlgebra.ldiv!(A, [vec(b.u); vec(b.jump_u)])
 end
 
 function recursivecopy!(dest::T, src::T) where {T <: ExtendedJumpArray}
     recursivecopy!(dest.u, src.u)
-    recursivecopy!(dest.jump_u, src.jump_u)
+    return recursivecopy!(dest.jump_u, src.jump_u)
 end
 Base.show(io::IO, A::ExtendedJumpArray) = show(io, A.u)
 plot_indices(A::ExtendedJumpArray) = eachindex(A.u)
@@ -128,46 +130,71 @@ plot_indices(A::ExtendedJumpArray) = eachindex(A.u)
 
 # The jump array styles stores two sub-styles in the type,
 # one for the `u` array and one for the `jump_u` array
-struct ExtendedJumpArrayStyle{UStyle <: Broadcast.BroadcastStyle,
-    JumpUStyle <: Broadcast.BroadcastStyle} <:
-       Broadcast.BroadcastStyle end
+struct ExtendedJumpArrayStyle{
+        UStyle <: Broadcast.BroadcastStyle,
+        JumpUStyle <: Broadcast.BroadcastStyle,
+    } <:
+    Broadcast.BroadcastStyle end
 # Init style based on type of u/jump_u
 function ExtendedJumpArrayStyle(::US, ::JumpUS) where {US, JumpUS}
-    ExtendedJumpArrayStyle{US, JumpUS}()
+    return ExtendedJumpArrayStyle{US, JumpUS}()
 end
-function Base.BroadcastStyle(::Type{ExtendedJumpArray{
-        T3, T1, UType, JumpUType}}) where {T3,
+function Base.BroadcastStyle(
+        ::Type{
+            ExtendedJumpArray{
+                T3, T1, UType, JumpUType,
+            },
+        }
+    ) where {
+        T3,
         T1,
         UType,
-        JumpUType
-}
-    ExtendedJumpArrayStyle(Base.BroadcastStyle(UType), Base.BroadcastStyle(JumpUType))
+        JumpUType,
+    }
+    return ExtendedJumpArrayStyle(Base.BroadcastStyle(UType), Base.BroadcastStyle(JumpUType))
 end
 
 # Combine with other styles by combining individually with u/jump_u styles
-function Base.BroadcastStyle(::ExtendedJumpArrayStyle{UStyle, JumpUStyle},
-        ::Style) where {UStyle, JumpUStyle,
-        Style <: Base.Broadcast.BroadcastStyle}
-    ExtendedJumpArrayStyle(Broadcast.result_style(UStyle(), Style()),
-        Broadcast.result_style(JumpUStyle(), Style()))
+function Base.BroadcastStyle(
+        ::ExtendedJumpArrayStyle{UStyle, JumpUStyle},
+        ::Style
+    ) where {
+        UStyle, JumpUStyle,
+        Style <: Base.Broadcast.BroadcastStyle,
+    }
+    return ExtendedJumpArrayStyle(
+        Broadcast.result_style(UStyle(), Style()),
+        Broadcast.result_style(JumpUStyle(), Style())
+    )
 end
 
 # Decay back to the DefaultArrayStyle for higher-order default styles, to support adding to raw vectors as needed
-function Base.BroadcastStyle(::ExtendedJumpArrayStyle{UStyle, JumpUStyle},
-        ::Broadcast.DefaultArrayStyle{0}) where {UStyle, JumpUStyle}
-    ExtendedJumpArrayStyle(UStyle(), JumpUStyle())
+function Base.BroadcastStyle(
+        ::ExtendedJumpArrayStyle{UStyle, JumpUStyle},
+        ::Broadcast.DefaultArrayStyle{0}
+    ) where {UStyle, JumpUStyle}
+    return ExtendedJumpArrayStyle(UStyle(), JumpUStyle())
 end
 
-function Base.BroadcastStyle(::ExtendedJumpArrayStyle{UStyle, JumpUStyle},
-        ::Broadcast.DefaultArrayStyle{N}) where {N, UStyle, JumpUStyle}
-    Broadcast.DefaultArrayStyle{N}()
+function Base.BroadcastStyle(
+        ::ExtendedJumpArrayStyle{UStyle, JumpUStyle},
+        ::Broadcast.DefaultArrayStyle{N}
+    ) where {N, UStyle, JumpUStyle}
+    return Broadcast.DefaultArrayStyle{N}()
 end
 
-function Base.Broadcast.BroadcastStyle(::S,
-        ::Base.Broadcast.Unknown) where {
-        UStyle, JumpUStyle, S <: JumpProcesses.ExtendedJumpArrayStyle{UStyle, JumpUStyle}}
-    return throw(ArgumentError("Cannot broadcast JumpProcesses.ExtendedJumpArray with" *
-                               " something of type Base.Broadcast.Unknown."),)
+function Base.Broadcast.BroadcastStyle(
+        ::S,
+        ::Base.Broadcast.Unknown
+    ) where {
+        UStyle, JumpUStyle, S <: JumpProcesses.ExtendedJumpArrayStyle{UStyle, JumpUStyle},
+    }
+    return throw(
+        ArgumentError(
+            "Cannot broadcast JumpProcesses.ExtendedJumpArray with" *
+                " something of type Base.Broadcast.Unknown."
+        ),
+    )
 end
 
 # Lookup the first ExtendedJumpArray to pick output container size
@@ -181,23 +208,29 @@ find_eja(::Tuple{}) = nothing
 find_eja(a::ExtendedJumpArray, rest) = a
 find_eja(::Any, rest) = find_eja(rest)
 
-function Base.similar(bc::Broadcast.Broadcasted{ExtendedJumpArrayStyle{US, JumpUS}},
-        ::Type{ElType}) where {US, JumpUS, ElType}
+function Base.similar(
+        bc::Broadcast.Broadcasted{ExtendedJumpArrayStyle{US, JumpUS}},
+        ::Type{ElType}
+    ) where {US, JumpUS, ElType}
     A = find_eja(bc)
-    ExtendedJumpArray(similar(A.u, ElType), similar(A.jump_u, ElType))
+    return ExtendedJumpArray(similar(A.u, ElType), similar(A.jump_u, ElType))
 end
 
 # Helper functions that repack broadcasted functions
 @inline function repack(bc::Broadcast.Broadcasted{Style}, i) where {Style}
-    Broadcast.Broadcasted{Style}(bc.f, repack_args(i, bc.args))
+    return Broadcast.Broadcasted{Style}(bc.f, repack_args(i, bc.args))
 end
-@inline function repack(bc::Broadcast.Broadcasted{ExtendedJumpArrayStyle{US, JumpUS}},
-        i::Val{:u}) where {US, JumpUS}
-    Broadcast.Broadcasted{US}(bc.f, repack_args(i, bc.args))
+@inline function repack(
+        bc::Broadcast.Broadcasted{ExtendedJumpArrayStyle{US, JumpUS}},
+        i::Val{:u}
+    ) where {US, JumpUS}
+    return Broadcast.Broadcasted{US}(bc.f, repack_args(i, bc.args))
 end
-@inline function repack(bc::Broadcast.Broadcasted{ExtendedJumpArrayStyle{US, JumpUS}},
-        i::Val{:jump_u}) where {US, JumpUS}
-    Broadcast.Broadcasted{JumpUS}(bc.f, repack_args(i, bc.args))
+@inline function repack(
+        bc::Broadcast.Broadcasted{ExtendedJumpArrayStyle{US, JumpUS}},
+        i::Val{:jump_u}
+    ) where {US, JumpUS}
+    return Broadcast.Broadcasted{JumpUS}(bc.f, repack_args(i, bc.args))
 end
 
 # Helper functions that repack arguments
@@ -215,19 +248,21 @@ end
     end
 end
 
-@inline function Base.copyto!(dest::ExtendedJumpArray,
-        bc::Broadcast.Broadcasted{ExtendedJumpArrayStyle{US, JumpUS}}) where {
+@inline function Base.copyto!(
+        dest::ExtendedJumpArray,
+        bc::Broadcast.Broadcasted{ExtendedJumpArrayStyle{US, JumpUS}}
+    ) where {
         US,
-        JumpUS
-}
+        JumpUS,
+    }
     copyto!(dest.u, repack(bc, Val(:u)))
     copyto!(dest.jump_u, repack(bc, Val(:jump_u)))
-    dest
+    return dest
 end
 
 Base.:*(x::ExtendedJumpArray, y::Number) = ExtendedJumpArray(y .* x.u, y .* x.jump_u)
 Base.:*(y::Number, x::ExtendedJumpArray) = ExtendedJumpArray(y .* x.u, y .* x.jump_u)
 Base.:/(x::ExtendedJumpArray, y::Number) = ExtendedJumpArray(x.u ./ y, x.jump_u ./ y)
 function Base.:+(x::ExtendedJumpArray, y::ExtendedJumpArray)
-    ExtendedJumpArray(x.u .+ y.u, x.jump_u .+ y.jump_u)
+    return ExtendedJumpArray(x.u .+ y.u, x.jump_u .+ y.jump_u)
 end

--- a/src/jumps.jl
+++ b/src/jumps.jl
@@ -171,15 +171,17 @@ function VariableRateJump(rate, affect!; lrate = nothing, urate = nothing,
                                          abstol = 1e-12, reltol = 0)
 ```
 """
-function VariableRateJump(rate, affect!;
+function VariableRateJump(
+        rate, affect!;
         lrate = nothing, urate = nothing,
         rateinterval = nothing, rootfind = true,
         idxs = nothing,
         save_positions = (false, true),
         interp_points = 10,
-        abstol = 1e-12, reltol = 0)
+        abstol = 1.0e-12, reltol = 0
+    )
     if !(urate !== nothing && rateinterval !== nothing) &&
-       !(urate === nothing && rateinterval === nothing)
+            !(urate === nothing && rateinterval === nothing)
         error("`urate` and `rateinterval` must both be `nothing`, or must both be defined.")
     end
 
@@ -188,8 +190,10 @@ function VariableRateJump(rate, affect!;
             error("If a lower bound rate, `lrate`, is given than an upper bound rate, `urate`, and rate interval, `rateinterval`, must also be provided.")
     end
 
-    VariableRateJump(rate, affect!, lrate, urate, rateinterval, idxs, rootfind,
-        interp_points, save_positions, abstol, reltol)
+    return VariableRateJump(
+        rate, affect!, lrate, urate, rateinterval, idxs, rootfind,
+        interp_points, save_positions, abstol, reltol
+    )
 end
 
 """
@@ -241,14 +245,14 @@ struct RegularJump{iip, R, C, MD}
     """ A distribution for marks. Not currently used or supported. """
     mark_dist::MD
     function RegularJump{iip}(rate, c, numjumps::Int; mark_dist = nothing) where {iip}
-        new{iip, typeof(rate), typeof(c), typeof(mark_dist)}(rate, c, numjumps, mark_dist)
+        return new{iip, typeof(rate), typeof(c), typeof(mark_dist)}(rate, c, numjumps, mark_dist)
     end
 end
 
 DiffEqBase.isinplace(::RegularJump{iip, R, C, MD}) where {iip, R, C, MD} = iip
 
 function RegularJump(rate, c, numjumps::Int; kwargs...)
-    RegularJump{DiffEqBase.isinplace(rate, 4)}(rate, c, numjumps; kwargs...)
+    return RegularJump{DiffEqBase.isinplace(rate, 4)}(rate, c, numjumps; kwargs...)
 end
 
 # deprecate old call
@@ -256,9 +260,9 @@ function RegularJump(rate, c, dc::AbstractMatrix; constant_c = false, mark_dist 
     @warn("The RegularJump interface has changed to be matrix-free. See the documentation for more details.")
     function _c(du, u, p, t, counts, mark)
         c(dc, u, p, t, mark)
-        mul!(du, dc, counts)
+        return mul!(du, dc, counts)
     end
-    RegularJump{true}(rate, _c, size(dc, 2); mark_dist = mark_dist)
+    return RegularJump{true}(rate, _c, size(dc, 2); mark_dist = mark_dist)
 end
 
 """
@@ -334,9 +338,11 @@ struct MassActionJump{T, S, U, V} <: AbstractMassActionJump
     """Parameter mapping functor to identify reaction rate constants with parameters in `p` vectors."""
     param_mapper::V
 
-    function MassActionJump{T, S, U, V}(rates::T, rs_in::S, ns::U, pmapper::V,
+    function MassActionJump{T, S, U, V}(
+            rates::T, rs_in::S, ns::U, pmapper::V,
             scale_rates::Bool, useiszero::Bool,
-            nocopy::Bool) where {T <: AbstractVector, S, U, V}
+            nocopy::Bool
+        ) where {T <: AbstractVector, S, U, V}
         sr = nocopy ? rates : copy(rates)
         rs = nocopy ? rs_in : copy(rs_in)
         for i in eachindex(rs)
@@ -348,61 +354,83 @@ struct MassActionJump{T, S, U, V} <: AbstractMassActionJump
         if scale_rates && !isempty(sr)
             scalerates!(sr, rs)
         end
-        new(sr, rs, ns, pmapper)
+        return new(sr, rs, ns, pmapper)
     end
-    function MassActionJump{Nothing, Vector{S},
-            Vector{U}, V}(::Nothing, rs_in::Vector{S},
+    function MassActionJump{
+            Nothing, Vector{S},
+            Vector{U}, V,
+        }(
+            ::Nothing, rs_in::Vector{S},
             ns::Vector{U}, pmapper::V,
             scale_rates::Bool,
             useiszero::Bool,
-            nocopy::Bool) where {S <: AbstractVector,
-            U <: AbstractVector, V}
+            nocopy::Bool
+        ) where {
+            S <: AbstractVector,
+            U <: AbstractVector, V,
+        }
         rs = nocopy ? rs_in : copy(rs_in)
         for i in eachindex(rs)
             if useiszero && (length(rs[i]) == 1) && iszero(rs[i][1][1])
                 rs[i] = typeof(rs[i])()
             end
         end
-        new(nothing, rs, ns, pmapper)
+        return new(nothing, rs, ns, pmapper)
     end
-    function MassActionJump{T, S, U, V}(rate::T, rs_in::S, ns::U, pmapper::V,
+    function MassActionJump{T, S, U, V}(
+            rate::T, rs_in::S, ns::U, pmapper::V,
             scale_rates::Bool, useiszero::Bool,
-            nocopy::Bool) where {T <: Number, S, U, V}
+            nocopy::Bool
+        ) where {T <: Number, S, U, V}
         rs = rs_in
         if useiszero && (length(rs) == 1) && iszero(rs[1][1])
             rs = typeof(rs)()
         end
         sr = scale_rates ? scalerate(rate, rs) : rate
-        new(sr, rs, ns, pmapper)
+        return new(sr, rs, ns, pmapper)
     end
-    function MassActionJump{Nothing, S, U, V}(::Nothing, rs_in::S, ns::U, pmapper::V,
+    function MassActionJump{Nothing, S, U, V}(
+            ::Nothing, rs_in::S, ns::U, pmapper::V,
             scale_rates::Bool, useiszero::Bool,
-            nocopy::Bool) where {S, U, V}
+            nocopy::Bool
+        ) where {S, U, V}
         rs = rs_in
         if useiszero && (length(rs) == 1) && iszero(rs[1][1])
             rs = typeof(rs)()
         end
-        new(nothing, rs, ns, pmapper)
+        return new(nothing, rs, ns, pmapper)
     end
 end
-function MassActionJump(usr::T, rs::S, ns::U, pmapper::V; scale_rates = true,
-        useiszero = true, nocopy = false) where {T, S, U, V}
-    MassActionJump{T, S, U, V}(usr, rs, ns, pmapper, scale_rates, useiszero, nocopy)
+function MassActionJump(
+        usr::T, rs::S, ns::U, pmapper::V; scale_rates = true,
+        useiszero = true, nocopy = false
+    ) where {T, S, U, V}
+    return MassActionJump{T, S, U, V}(usr, rs, ns, pmapper, scale_rates, useiszero, nocopy)
 end
-function MassActionJump(usr::T, rs, ns; scale_rates = true, useiszero = true,
-        nocopy = false) where {T <: AbstractVector}
-    MassActionJump(usr, rs, ns, nothing; scale_rates = scale_rates, useiszero = useiszero,
-        nocopy = nocopy)
+function MassActionJump(
+        usr::T, rs, ns; scale_rates = true, useiszero = true,
+        nocopy = false
+    ) where {T <: AbstractVector}
+    return MassActionJump(
+        usr, rs, ns, nothing; scale_rates = scale_rates, useiszero = useiszero,
+        nocopy = nocopy
+    )
 end
-function MassActionJump(usr::T, rs, ns; scale_rates = true, useiszero = true,
-        nocopy = false) where {T <: Number}
-    MassActionJump(usr, rs, ns, nothing; scale_rates = scale_rates, useiszero = useiszero,
-        nocopy = nocopy)
+function MassActionJump(
+        usr::T, rs, ns; scale_rates = true, useiszero = true,
+        nocopy = false
+    ) where {T <: Number}
+    return MassActionJump(
+        usr, rs, ns, nothing; scale_rates = scale_rates, useiszero = useiszero,
+        nocopy = nocopy
+    )
 end
 
 # with parameter indices or mapping, multiple jump case
-function MassActionJump(rs, ns; param_idxs = nothing, param_mapper = nothing,
-        scale_rates = true, useiszero = true, nocopy = false)
+function MassActionJump(
+        rs, ns; param_idxs = nothing, param_mapper = nothing,
+        scale_rates = true, useiszero = true, nocopy = false
+    )
     if param_mapper === nothing
         (param_idxs === nothing) &&
             error("If no parameter indices are given via param_idxs, an explicit parameter mapping must be passed in via param_mapper.")
@@ -413,8 +441,10 @@ function MassActionJump(rs, ns; param_idxs = nothing, param_mapper = nothing,
         pmapper = param_mapper
     end
 
-    MassActionJump(nothing, nocopy ? rs : copy(rs), ns, pmapper; scale_rates = scale_rates,
-        useiszero = useiszero, nocopy = true)
+    return MassActionJump(
+        nothing, nocopy ? rs : copy(rs), ns, pmapper; scale_rates = scale_rates,
+        useiszero = useiszero, nocopy = true
+    )
 end
 
 using_params(maj::MassActionJump{T, S, U, Nothing}) where {T, S, U} = false
@@ -430,43 +460,53 @@ end
 # create the initial parameter vector for use in a MassActionJump
 # Note these are unscaled
 function (ratemap::MassActionJumpParamMapper{U})(params) where {U <: AbstractArray}
-    [params[pidx] for pidx in ratemap.param_idxs]
+    return [params[pidx] for pidx in ratemap.param_idxs]
 end
 
 # Note this is unscaled
 function (ratemap::MassActionJumpParamMapper{U})(params) where {U <: Int}
-    params[ratemap.param_idxs]
+    return params[ratemap.param_idxs]
 end
 
 # update a maj with parameter vectors
-function (ratemap::MassActionJumpParamMapper{U})(maj::MassActionJump, newparams;
+function (ratemap::MassActionJumpParamMapper{U})(
+        maj::MassActionJump, newparams;
         scale_rates,
-        kwargs...) where {U <: AbstractArray}
+        kwargs...
+    ) where {U <: AbstractArray}
     for i in 1:get_num_majumps(maj)
         maj.scaled_rates[i] = newparams[ratemap.param_idxs[i]]
     end
     scale_rates && scalerates!(maj.scaled_rates, maj.reactant_stoch)
-    nothing
+    return nothing
 end
 
 function to_collection(ratemap::MassActionJumpParamMapper{Int})
-    MassActionJumpParamMapper([ratemap.param_idxs])
+    return MassActionJumpParamMapper([ratemap.param_idxs])
 end
 
-function Base.merge!(pmap1::MassActionJumpParamMapper{U},
-        pmap2::MassActionJumpParamMapper{U}) where {U <: AbstractVector}
-    append!(pmap1.param_idxs, pmap2.param_idxs)
+function Base.merge!(
+        pmap1::MassActionJumpParamMapper{U},
+        pmap2::MassActionJumpParamMapper{U}
+    ) where {U <: AbstractVector}
+    return append!(pmap1.param_idxs, pmap2.param_idxs)
 end
 
-function Base.merge!(pmap1::MassActionJumpParamMapper{U},
-        pmap2::MassActionJumpParamMapper{V}) where {U <: AbstractVector,
-        V <: Int}
-    push!(pmap1.param_idxs, pmap2.param_idxs)
+function Base.merge!(
+        pmap1::MassActionJumpParamMapper{U},
+        pmap2::MassActionJumpParamMapper{V}
+    ) where {
+        U <: AbstractVector,
+        V <: Int,
+    }
+    return push!(pmap1.param_idxs, pmap2.param_idxs)
 end
 
-function Base.merge(pmap1::MassActionJumpParamMapper{Int},
-        pmap2::MassActionJumpParamMapper{Int})
-    MassActionJumpParamMapper([pmap1.param_idxs, pmap2.param_idxs])
+function Base.merge(
+        pmap1::MassActionJumpParamMapper{Int},
+        pmap2::MassActionJumpParamMapper{Int}
+    )
+    return MassActionJumpParamMapper([pmap1.param_idxs, pmap2.param_idxs])
 end
 
 """
@@ -484,7 +524,7 @@ Notes:
 function update_parameters!(maj::MassActionJump, newparams; scale_rates = true, kwargs...)
     (maj.param_mapper === nothing) &&
         error("MassActionJumps must be constructed with param_idxs or a param_mapper to be updateable.")
-    maj.param_mapper(maj, newparams; scale_rates, kwargs)
+    return maj.param_mapper(maj, newparams; scale_rates, kwargs)
 end
 
 """
@@ -532,22 +572,24 @@ struct JumpSet{T1, T2, T3, T4} <: AbstractJump
     massaction_jump::T4
 end
 function JumpSet(vj, cj, rj, maj::MassActionJump{S, T, U, V}) where {S <: Number, T, U, V}
-    JumpSet(vj, cj, rj, check_majump_type(maj))
+    return JumpSet(vj, cj, rj, check_majump_type(maj))
 end
 
 JumpSet(jump::ConstantRateJump) = JumpSet((), (jump,), nothing, nothing)
 JumpSet(jump::VariableRateJump) = JumpSet((jump,), (), nothing, nothing)
 JumpSet(jump::RegularJump) = JumpSet((), (), jump, nothing)
 JumpSet(jump::AbstractMassActionJump) = JumpSet((), (), nothing, jump)
-function JumpSet(; variable_jumps = (), constant_jumps = (),
-        regular_jumps = nothing, massaction_jumps = nothing)
-    JumpSet(variable_jumps, constant_jumps, regular_jumps, massaction_jumps)
+function JumpSet(;
+        variable_jumps = (), constant_jumps = (),
+        regular_jumps = nothing, massaction_jumps = nothing
+    )
+    return JumpSet(variable_jumps, constant_jumps, regular_jumps, massaction_jumps)
 end
 JumpSet(jb::Nothing) = JumpSet()
 
 # For Varargs, use recursion to make it type-stable
 function JumpSet(jumps::AbstractJump...)
-    JumpSet(split_jumps((), (), nothing, nothing, jumps...)...)
+    return JumpSet(split_jumps((), (), nothing, nothing, jumps...)...)
 end
 
 # handle vector of mass action jumps
@@ -556,32 +598,34 @@ function JumpSet(vjs, cjs, rj, majv::Vector{T}) where {T <: MassActionJump}
         error("JumpSets do not accept empty mass action jump collections; use \"nothing\" instead.")
     end
 
-    maj = setup_majump_to_merge(majv[1].scaled_rates, majv[1].reactant_stoch,
-        majv[1].net_stoch, majv[1].param_mapper)
+    maj = setup_majump_to_merge(
+        majv[1].scaled_rates, majv[1].reactant_stoch,
+        majv[1].net_stoch, majv[1].param_mapper
+    )
     for i in 2:length(majv)
         massaction_jump_combine(maj, majv[i])
     end
 
-    JumpSet(vjs, cjs, rj, maj)
+    return JumpSet(vjs, cjs, rj, maj)
 end
 
 @inline get_num_majumps(jset::JumpSet) = get_num_majumps(jset.massaction_jump)
 @inline num_majumps(jset::JumpSet) = get_num_majumps(jset)
 
 @inline function num_crjs(jset::JumpSet)
-    (jset.constant_jumps !== nothing) ? length(jset.constant_jumps) : 0
+    return (jset.constant_jumps !== nothing) ? length(jset.constant_jumps) : 0
 end
 
 @inline function num_vrjs(jset::JumpSet)
-    (jset.variable_jumps !== nothing) ? length(jset.variable_jumps) : 0
+    return (jset.variable_jumps !== nothing) ? length(jset.variable_jumps) : 0
 end
 
 @inline function num_bndvrjs(jset::JumpSet)
-    (jset.variable_jumps !== nothing) ? count(isbounded, jset.variable_jumps) : 0
+    return (jset.variable_jumps !== nothing) ? count(isbounded, jset.variable_jumps) : 0
 end
 
 @inline function num_continvrjs(jset::JumpSet)
-    (jset.variable_jumps !== nothing) ? count(!isbounded, jset.variable_jumps) : 0
+    return (jset.variable_jumps !== nothing) ? count(!isbounded, jset.variable_jumps) : 0
 end
 
 num_jumps(jset::JumpSet) = num_majumps(jset) + num_crjs(jset) + num_vrjs(jset)
@@ -590,22 +634,24 @@ num_cdiscretejumps(jset::JumpSet) = num_majumps(jset) + num_crjs(jset)
 
 @inline split_jumps(vj, cj, rj, maj) = vj, cj, rj, maj
 @inline function split_jumps(vj, cj, rj, maj, v::VariableRateJump, args...)
-    split_jumps((vj..., v), cj, rj, maj, args...)
+    return split_jumps((vj..., v), cj, rj, maj, args...)
 end
 @inline function split_jumps(vj, cj, rj, maj, c::ConstantRateJump, args...)
-    split_jumps(vj, (cj..., c), rj, maj, args...)
+    return split_jumps(vj, (cj..., c), rj, maj, args...)
 end
 @inline function split_jumps(vj, cj, rj, maj, c::RegularJump, args...)
-    split_jumps(vj, cj, regular_jump_combine(rj, c), maj, args...)
+    return split_jumps(vj, cj, regular_jump_combine(rj, c), maj, args...)
 end
 @inline function split_jumps(vj, cj, rj, maj, c::MassActionJump, args...)
-    split_jumps(vj, cj, rj, massaction_jump_combine(maj, c), args...)
+    return split_jumps(vj, cj, rj, massaction_jump_combine(maj, c), args...)
 end
 @inline function split_jumps(vj, cj, rj, maj, j::JumpSet, args...)
-    split_jumps((vj..., j.variable_jumps...),
+    return split_jumps(
+        (vj..., j.variable_jumps...),
         (cj..., j.constant_jumps...),
         regular_jump_combine(rj, j.regular_jump),
-        massaction_jump_combine(maj, j.massaction_jump), args...)
+        massaction_jump_combine(maj, j.massaction_jump), args...
+    )
 end
 
 regular_jump_combine(rj1::RegularJump, rj2::Nothing) = rj1
@@ -617,43 +663,65 @@ end
 
 # functionality to merge two mass action jumps together
 function check_majump_type(maj::MassActionJump{S, T, U, V}) where {S <: Number, T, U, V}
-    setup_majump_to_merge(maj.scaled_rates, maj.reactant_stoch, maj.net_stoch,
-        maj.param_mapper)
+    return setup_majump_to_merge(
+        maj.scaled_rates, maj.reactant_stoch, maj.net_stoch,
+        maj.param_mapper
+    )
 end
 function check_majump_type(maj::MassActionJump{Nothing, T, U, V}) where {T, U, V}
-    setup_majump_to_merge(maj.scaled_rates, maj.reactant_stoch, maj.net_stoch,
-        maj.param_mapper)
+    return setup_majump_to_merge(
+        maj.scaled_rates, maj.reactant_stoch, maj.net_stoch,
+        maj.param_mapper
+    )
 end
 
 # if given containers of rates and stoichiometry directly create a jump
-function setup_majump_to_merge(sr::T, rs::AbstractVector{S}, ns::AbstractVector{U},
-        pmapper) where {T <: AbstractVector, S <: AbstractArray,
-        U <: AbstractArray}
-    MassActionJump(sr, rs, ns, pmapper; scale_rates = false)
+function setup_majump_to_merge(
+        sr::T, rs::AbstractVector{S}, ns::AbstractVector{U},
+        pmapper
+    ) where {
+        T <: AbstractVector, S <: AbstractArray,
+        U <: AbstractArray,
+    }
+    return MassActionJump(sr, rs, ns, pmapper; scale_rates = false)
 end
 
 # if just given the data for one jump (and not in a container) wrap in a vector
-function setup_majump_to_merge(sr::S, rs::T, ns::U,
-        pmapper) where {S <: Number, T <: AbstractArray,
-        U <: AbstractArray}
-    MassActionJump([sr], [rs], [ns],
+function setup_majump_to_merge(
+        sr::S, rs::T, ns::U,
+        pmapper
+    ) where {
+        S <: Number, T <: AbstractArray,
+        U <: AbstractArray,
+    }
+    return MassActionJump(
+        [sr], [rs], [ns],
         (pmapper === nothing) ? pmapper : to_collection(pmapper);
-        scale_rates = false)
+        scale_rates = false
+    )
 end
 
 # if no rate field setup yet
-function setup_majump_to_merge(::Nothing, rs::T, ns::U,
-        pmapper) where {T <: AbstractArray, U <: AbstractArray}
-    MassActionJump(nothing, [rs], [ns],
+function setup_majump_to_merge(
+        ::Nothing, rs::T, ns::U,
+        pmapper
+    ) where {T <: AbstractArray, U <: AbstractArray}
+    return MassActionJump(
+        nothing, [rs], [ns],
         (pmapper === nothing) ? pmapper : to_collection(pmapper);
-        scale_rates = false)
+        scale_rates = false
+    )
 end
 
 # when given a collection of reactions to add to maj
-function majump_merge!(maj::MassActionJump{U, <:AbstractVector{V}, <:AbstractVector{W}, X},
+function majump_merge!(
+        maj::MassActionJump{U, <:AbstractVector{V}, <:AbstractVector{W}, X},
         sr::U, rs::AbstractVector{V}, ns::AbstractVector{W},
-        param_mapper) where {U <: Union{AbstractVector, Nothing},
-        V <: AbstractVector, W <: AbstractVector, X}
+        param_mapper
+    ) where {
+        U <: Union{AbstractVector, Nothing},
+        V <: AbstractVector, W <: AbstractVector, X,
+    }
     (U <: AbstractVector) && append!(maj.scaled_rates, sr)
     append!(maj.reactant_stoch, rs)
     append!(maj.net_stoch, ns)
@@ -663,16 +731,20 @@ function majump_merge!(maj::MassActionJump{U, <:AbstractVector{V}, <:AbstractVec
     else
         merge!(maj.param_mapper, param_mapper)
     end
-    maj
+    return maj
 end
 
 # when given a single jump's worth of data to add to maj
-function majump_merge!(maj::MassActionJump{U, V, W, X}, sr::T, rs::S1, ns::S2,
-        param_mapper) where {T <: Union{Number, Nothing},
+function majump_merge!(
+        maj::MassActionJump{U, V, W, X}, sr::T, rs::S1, ns::S2,
+        param_mapper
+    ) where {
+        T <: Union{Number, Nothing},
         S1 <: AbstractArray, S2 <: AbstractArray,
         U <: Union{AbstractVector{T}, Nothing},
         V <: AbstractVector{S1},
-        W <: AbstractVector{S2}, X}
+        W <: AbstractVector{S2}, X,
+    }
     (T <: Number) && push!(maj.scaled_rates, sr)
     push!(maj.reactant_stoch, rs)
     push!(maj.net_stoch, ns)
@@ -683,24 +755,32 @@ function majump_merge!(maj::MassActionJump{U, V, W, X}, sr::T, rs::S1, ns::S2,
         merge!(maj.param_mapper, param_mapper)
     end
 
-    maj
+    return maj
 end
 
 # when maj only stores a single jump's worth of data (and not in a collection)
 # create a new jump with the merged data stored in vectors
-function majump_merge!(maj::MassActionJump{T, S, U, V}, sr::T, rs::S, ns::U,
-        param_mapper::V) where {T <: Union{Number, Nothing},
+function majump_merge!(
+        maj::MassActionJump{T, S, U, V}, sr::T, rs::S, ns::U,
+        param_mapper::V
+    ) where {
+        T <: Union{Number, Nothing},
         S <: AbstractArray{<:Pair},
-        U <: AbstractArray{<:Pair}, V}
+        U <: AbstractArray{<:Pair}, V,
+    }
     rates = (T <: Nothing) ? nothing : [maj.scaled_rates, sr]
     if maj.param_mapper === nothing
         (param_mapper === nothing) ||
             error("Error, trying to merge a MassActionJump with a parameter mapping to one without a parameter mapping.")
-        return MassActionJump(rates, [maj.reactant_stoch, rs], [maj.net_stoch, ns],
-            param_mapper; scale_rates = false)
+        return MassActionJump(
+            rates, [maj.reactant_stoch, rs], [maj.net_stoch, ns],
+            param_mapper; scale_rates = false
+        )
     else
-        return MassActionJump(rates, [maj.reactant_stoch, rs], [maj.net_stoch, ns],
-            merge(maj.param_mapper, param_mapper); scale_rates = false)
+        return MassActionJump(
+            rates, [maj.reactant_stoch, rs], [maj.net_stoch, ns],
+            merge(maj.param_mapper, param_mapper); scale_rates = false
+        )
     end
 end
 
@@ -708,8 +788,10 @@ massaction_jump_combine(maj1::MassActionJump, maj2::Nothing) = maj1
 massaction_jump_combine(maj1::Nothing, maj2::MassActionJump) = maj2
 massaction_jump_combine(maj1::Nothing, maj2::Nothing) = maj1
 function massaction_jump_combine(maj1::MassActionJump, maj2::MassActionJump)
-    majump_merge!(maj1, maj2.scaled_rates, maj2.reactant_stoch, maj2.net_stoch,
-        maj2.param_mapper)
+    return majump_merge!(
+        maj1, maj2.scaled_rates, maj2.reactant_stoch, maj2.net_stoch,
+        maj2.param_mapper
+    )
 end
 
 ##### helper methods for unpacking rates and affects! from constant jumps #####
@@ -722,12 +804,14 @@ function get_jump_info_tuples(jumps)
         affects! = ()
     end
 
-    rates, affects!
+    return rates, affects!
 end
 
 function get_jump_info_fwrappers(u, p, t, jumps)
-    RateWrapper = FunctionWrappers.FunctionWrapper{typeof(t),
-        Tuple{typeof(u), typeof(p), typeof(t)}}
+    RateWrapper = FunctionWrappers.FunctionWrapper{
+        typeof(t),
+        Tuple{typeof(u), typeof(p), typeof(t)},
+    }
 
     if (jumps !== nothing) && !isempty(jumps)
         rates = [RateWrapper(c.rate) for c in jumps]
@@ -737,5 +821,5 @@ function get_jump_info_fwrappers(u, p, t, jumps)
         affects! = Any[]
     end
 
-    rates, affects!
+    return rates, affects!
 end

--- a/src/simple_regular_solve.jl
+++ b/src/simple_regular_solve.jl
@@ -6,16 +6,18 @@ function validate_pure_leaping_inputs(jump_prob::JumpProblem, alg)
         JumpProblem, i.e. call JumpProblem(::DiscreteProblem, PureLeaping(),...). \
         Passing $(jump_prob.aggregator) is deprecated and will be removed in the next breaking release."
     end
-    isempty(jump_prob.jump_callback.continuous_callbacks) &&
-    isempty(jump_prob.jump_callback.discrete_callbacks) &&
-    isempty(jump_prob.constant_jumps) &&
-    isempty(jump_prob.variable_jumps) &&
-    get_num_majumps(jump_prob.massaction_jump) == 0 &&
-    jump_prob.regular_jump !== nothing    
+    return isempty(jump_prob.jump_callback.continuous_callbacks) &&
+        isempty(jump_prob.jump_callback.discrete_callbacks) &&
+        isempty(jump_prob.constant_jumps) &&
+        isempty(jump_prob.variable_jumps) &&
+        get_num_majumps(jump_prob.massaction_jump) == 0 &&
+        jump_prob.regular_jump !== nothing
 end
 
-function DiffEqBase.solve(jump_prob::JumpProblem, alg::SimpleTauLeaping;
-        seed = nothing, dt = error("dt is required for SimpleTauLeaping."))
+function DiffEqBase.solve(
+        jump_prob::JumpProblem, alg::SimpleTauLeaping;
+        seed = nothing, dt = error("dt is required for SimpleTauLeaping.")
+    )
     validate_pure_leaping_inputs(jump_prob, alg) ||
         error("SimpleTauLeaping can only be used with PureLeaping JumpProblems with only RegularJumps.")
 
@@ -56,9 +58,11 @@ function DiffEqBase.solve(jump_prob::JumpProblem, alg::SimpleTauLeaping;
         u[i] = du + uprev
     end
 
-    sol = DiffEqBase.build_solution(prob, alg, t, u,
+    return sol = DiffEqBase.build_solution(
+        prob, alg, t, u,
         calculate_error = false,
-        interp = DiffEqBase.ConstantInterpolation(t, u))
+        interp = DiffEqBase.ConstantInterpolation(t, u)
+    )
 end
 
 struct EnsembleGPUKernel{Backend} <: SciMLBase.EnsembleAlgorithm
@@ -67,9 +71,9 @@ struct EnsembleGPUKernel{Backend} <: SciMLBase.EnsembleAlgorithm
 end
 
 function EnsembleGPUKernel(backend)
-    EnsembleGPUKernel(backend, 0.0)
+    return EnsembleGPUKernel(backend, 0.0)
 end
 
 function EnsembleGPUKernel()
-    EnsembleGPUKernel(nothing, 0.0)
+    return EnsembleGPUKernel(nothing, 0.0)
 end

--- a/src/spatial/bracketing.jl
+++ b/src/spatial/bracketing.jl
@@ -12,21 +12,21 @@ end
 
 function Base.show(io::IO, ::MIME"text/plain", low_high::LowHigh)
     println(io, "Low: \n $(low_high.low)")
-    println(io, "High: \n $(low_high.high)")
+    return println(io, "High: \n $(low_high.high)")
 end
 
 @inline function update_u_brackets!(u_low_high::LowHigh, bracket_data, u::AbstractMatrix)
     @inbounds for (i, uval) in enumerate(u)
         u_low_high[i] = LowHigh(get_spec_brackets(bracket_data, i, uval))
     end
-    nothing
+    return nothing
 end
 
 ### convenience functions for LowHigh ###
 function setindex!(low_high::LowHigh, val::LowHigh, i)
     low_high.low[i] = val.low
     low_high.high[i] = val.high
-    val
+    return val
 end
 
 function getindex(low_high::LowHigh, i)
@@ -36,15 +36,16 @@ end
 function total_site_rate(rx_rates::LowHigh, hop_rates::LowHigh, site)
     return LowHigh(
         total_site_rate(rx_rates.low, hop_rates.low, site),
-        total_site_rate(rx_rates.high, hop_rates.high, site))
+        total_site_rate(rx_rates.high, hop_rates.high, site)
+    )
 end
 
 function update_rx_rates!(rx_rates::LowHigh, rxs, u_low_high, integrator, site)
     update_rx_rates!(rx_rates.low, rxs, u_low_high.low, integrator, site)
-    update_rx_rates!(rx_rates.high, rxs, u_low_high.high, integrator, site)
+    return update_rx_rates!(rx_rates.high, rxs, u_low_high.high, integrator, site)
 end
 
 function update_hop_rates!(hop_rates::LowHigh, species, u_low_high, site, spatial_system)
     update_hop_rates!(hop_rates.low, species, u_low_high.low, site, spatial_system)
-    update_hop_rates!(hop_rates.high, species, u_low_high.high, site, spatial_system)
+    return update_hop_rates!(hop_rates.high, species, u_low_high.high, site, spatial_system)
 end

--- a/src/spatial/flatten.jl
+++ b/src/spatial/flatten.jl
@@ -3,14 +3,18 @@ using JumpProcesses, DiffEqBase, Graphs
 """
 prob.u0 must be a Matrix with prob.u0[i,j] being the number of species i at site j
 """
-function flatten(ma_jump, prob::DiscreteProblem, spatial_system, hopping_constants;
-        kwargs...)
+function flatten(
+        ma_jump, prob::DiscreteProblem, spatial_system, hopping_constants;
+        kwargs...
+    )
     tspan = prob.tspan
     u0 = prob.u0
     if ma_jump === nothing
-        ma_jump = MassActionJump(Vector{typeof(tspan[1])}(),
+        ma_jump = MassActionJump(
+            Vector{typeof(tspan[1])}(),
             Vector{Vector{Pair{Int, eltype(u0)}}}(),
-            Vector{Vector{Pair{Int, eltype(u0)}}}())
+            Vector{Vector{Pair{Int, eltype(u0)}}}()
+        )
     end
     netstoch = ma_jump.net_stoch
     reactstoch = ma_jump.reactant_stoch
@@ -23,57 +27,75 @@ function flatten(ma_jump, prob::DiscreteProblem, spatial_system, hopping_constan
         elseif isnothing(ma_jump.uniform_rates)
             ma_jump.spatial_rates
         elseif isnothing(ma_jump.spatial_rates)
-            reshape(repeat(ma_jump.uniform_rates, num_nodes),
-                length(ma_jump.uniform_rates), num_nodes)
+            reshape(
+                repeat(ma_jump.uniform_rates, num_nodes),
+                length(ma_jump.uniform_rates), num_nodes
+            )
         else
             @assert size(ma_jump.spatial_rates, 2) == num_nodes
-            cat(dims = 1,
-                reshape(repeat(ma_jump.uniform_rates, num_nodes),
-                    length(ma_jump.uniform_rates), num_nodes),
-                ma_jump.spatial_rates)
+            cat(
+                dims = 1,
+                reshape(
+                    repeat(ma_jump.uniform_rates, num_nodes),
+                    length(ma_jump.uniform_rates), num_nodes
+                ),
+                ma_jump.spatial_rates
+            )
         end
     else
         error("flatten: unsupported jump type $(typeof(ma_jump))")
     end
-    flatten(netstoch, reactstoch, rx_rates, spatial_system, u0, tspan, hopping_constants;
-        scale_rates = false, kwargs...)
+    return flatten(
+        netstoch, reactstoch, rx_rates, spatial_system, u0, tspan, hopping_constants;
+        scale_rates = false, kwargs...
+    )
 end
 
 """
 if hopping_constants is a matrix, assume hopping_constants[i,j] is the hopping constant of species i from site j to any neighbor
 """
-function flatten(netstoch::AbstractArray, reactstoch::AbstractArray,
+function flatten(
+        netstoch::AbstractArray, reactstoch::AbstractArray,
         rx_rates::AbstractArray, spatial_system, u0::Matrix{Int}, tspan,
-        hopping_constants::Matrix{F}; kwargs...) where {F <: Number}
+        hopping_constants::Matrix{F}; kwargs...
+    ) where {F <: Number}
     @assert size(hopping_constants) == size(u0)
     hop_constants = Matrix{Vector{F}}(undef, size(hopping_constants))
     for ci in CartesianIndices(hop_constants)
         (species, site) = Tuple(ci)
         hop_constants[ci] = hopping_constants[species, site] * ones(outdegree(spatial_system, site))
     end
-    flatten(netstoch, reactstoch, rx_rates, spatial_system, u0, tspan, hop_constants;
-        kwargs...)
+    return flatten(
+        netstoch, reactstoch, rx_rates, spatial_system, u0, tspan, hop_constants;
+        kwargs...
+    )
 end
 
 """
 if reaction rates is a vector, assume reaction rates are equal across sites
 """
-function flatten(netstoch::AbstractArray, reactstoch::AbstractArray, rx_rates::Vector,
+function flatten(
+        netstoch::AbstractArray, reactstoch::AbstractArray, rx_rates::Vector,
         spatial_system, u0::Matrix{Int}, tspan,
-        hopping_constants::Matrix{Vector{F}}; kwargs...) where {F <: Number}
+        hopping_constants::Matrix{Vector{F}}; kwargs...
+    ) where {F <: Number}
     num_nodes = num_sites(spatial_system)
     rates = reshape(repeat(rx_rates, num_nodes), length(rx_rates), num_nodes)
-    flatten(netstoch, reactstoch, rates, spatial_system, u0, tspan, hopping_constants;
-        kwargs...)
+    return flatten(
+        netstoch, reactstoch, rates, spatial_system, u0, tspan, hopping_constants;
+        kwargs...
+    )
 end
 
 """
 "flatten" the spatial jump problem. Return flattened DiscreteProblem and MassActionJump.
 """
-function flatten(netstoch::Vector{R}, reactstoch::Vector{R}, rx_rates::Matrix{F},
+function flatten(
+        netstoch::Vector{R}, reactstoch::Vector{R}, rx_rates::Matrix{F},
         spatial_system, u0::Matrix{Int}, tspan,
         hopping_constants::Matrix{Vector{F}}; scale_rates = true,
-        kwargs...) where {R, F <: Number}
+        kwargs...
+    ) where {R, F <: Number}
     num_species = size(u0, 1)
     num_nodes = num_sites(spatial_system)
     num_rxs = length(reactstoch)
@@ -119,9 +141,11 @@ function flatten(netstoch::Vector{R}, reactstoch::Vector{R}, rx_rates::Matrix{F}
     append!(total_rates, vec(rx_rates)) # assuming rx_rates isa Matrix where rx_rates[rx, site] is the rate of rx at site
 
     # put everything together
-    ma_jump = MassActionJump(total_rates, total_reactstoch, total_netstoch; nocopy = true,
-        scale_rates = scale_rates)
+    ma_jump = MassActionJump(
+        total_rates, total_reactstoch, total_netstoch; nocopy = true,
+        scale_rates = scale_rates
+    )
     flattened_u0 = vec(u0)
     prob = DiscreteProblem(flattened_u0, tspan, total_rates)
-    prob, ma_jump
+    return prob, ma_jump
 end

--- a/src/spatial/hop_rates.jl
+++ b/src/spatial/hop_rates.jl
@@ -11,49 +11,67 @@ A file with structs and functions for sampling hops and updating hopping rates
 abstract type AbstractHopRates end
 
 function HopRates(hopping_constants::Vector{F}, spatial_system) where {F <: Number}
-    HopRatesGraphDs(hopping_constants, num_sites(spatial_system))
+    return HopRatesGraphDs(hopping_constants, num_sites(spatial_system))
 end
-function HopRates(hopping_constants::Vector{F},
-        grid::CartesianGridRej) where {F <: Number}
-    HopRatesGraphDs(hopping_constants, num_sites(grid))
+function HopRates(
+        hopping_constants::Vector{F},
+        grid::CartesianGridRej
+    ) where {F <: Number}
+    return HopRatesGraphDs(hopping_constants, num_sites(grid))
 end
 
 function HopRates(hopping_constants::Matrix{F}, spatial_system) where {F <: Number}
-    HopRatesGraphDsi(hopping_constants)
+    return HopRatesGraphDsi(hopping_constants)
 end
-function HopRates(hopping_constants::Matrix{F},
-        grid::CartesianGridRej) where {F <: Number}
-    HopRatesGraphDsi(hopping_constants)
+function HopRates(
+        hopping_constants::Matrix{F},
+        grid::CartesianGridRej
+    ) where {F <: Number}
+    return HopRatesGraphDsi(hopping_constants)
 end
 
 function HopRates(hopping_constants::Matrix{Vector{F}}, spatial_system) where {F <: Number}
-    HopRatesGraphDsij(hopping_constants)
+    return HopRatesGraphDsij(hopping_constants)
 end
-function HopRates(hopping_constants::Matrix{Vector{F}},
-        grid::CartesianGridRej) where {F <: Number}
-    HopRatesGridDsij(hopping_constants, grid)
-end
-
-function HopRates(p::Pair{SpecHop, SiteHop},
-        spatial_system) where {F <: Number, SpecHop <: Vector{F},
-        SiteHop <: Vector{Vector{F}}}
-    HopRatesGraphDsLij(p...)
-end
-function HopRates(p::Pair{SpecHop, SiteHop},
-        grid::CartesianGridRej) where
-        {F <: Number, SpecHop <: Vector{F}, SiteHop <: Vector{Vector{F}}}
-    HopRatesGridDsLij(p..., grid)
+function HopRates(
+        hopping_constants::Matrix{Vector{F}},
+        grid::CartesianGridRej
+    ) where {F <: Number}
+    return HopRatesGridDsij(hopping_constants, grid)
 end
 
-function HopRates(p::Pair{SpecHop, SiteHop},
-        spatial_system) where {F <: Number, SpecHop <: Matrix{F},
-        SiteHop <: Vector{Vector{F}}}
-    HopRatesGraphDsiLij(p...)
+function HopRates(
+        p::Pair{SpecHop, SiteHop},
+        spatial_system
+    ) where {
+        F <: Number, SpecHop <: Vector{F},
+        SiteHop <: Vector{Vector{F}},
+    }
+    return HopRatesGraphDsLij(p...)
 end
-function HopRates(p::Pair{SpecHop, SiteHop},
-        grid::CartesianGridRej) where
-        {SpecHop <: Matrix{F}, SiteHop <: Vector{Vector{F}}} where {F <: Number}
-    HopRatesGridDsiLij(p..., grid)
+function HopRates(
+        p::Pair{SpecHop, SiteHop},
+        grid::CartesianGridRej
+    ) where
+    {F <: Number, SpecHop <: Vector{F}, SiteHop <: Vector{Vector{F}}}
+    return HopRatesGridDsLij(p..., grid)
+end
+
+function HopRates(
+        p::Pair{SpecHop, SiteHop},
+        spatial_system
+    ) where {
+        F <: Number, SpecHop <: Matrix{F},
+        SiteHop <: Vector{Vector{F}},
+    }
+    return HopRatesGraphDsiLij(p...)
+end
+function HopRates(
+        p::Pair{SpecHop, SiteHop},
+        grid::CartesianGridRej
+    ) where
+    {SpecHop <: Matrix{F}, SiteHop <: Vector{Vector{F}}} where {F <: Number}
+    return HopRatesGridDsiLij(p..., grid)
 end
 
 """
@@ -61,9 +79,11 @@ end
 
 update rates of all specs in species at site
 """
-function update_hop_rates!(hop_rates::AbstractHopRates, species::AbstractArray, u, site,
-        spatial_system)
-    @inbounds for spec in species
+function update_hop_rates!(
+        hop_rates::AbstractHopRates, species::AbstractArray, u, site,
+        spatial_system
+    )
+    return @inbounds for spec in species
         update_hop_rate!(hop_rates, spec, u, site, spatial_system)
     end
 end
@@ -76,10 +96,12 @@ update rates of single species at site
 function update_hop_rate!(hop_rates::AbstractHopRates, species, u, site, spatial_system)
     rates = hop_rates.rates
     @inbounds old_rate = rates[species, site]
-    @inbounds rates[species, site] = evalhoprate(hop_rates, u, species, site,
-        spatial_system)
+    @inbounds rates[species, site] = evalhoprate(
+        hop_rates, u, species, site,
+        spatial_system
+    )
     @inbounds hop_rates.sum_rates[site] += rates[species, site] - old_rate
-    old_rate
+    return old_rate
 end
 
 """
@@ -97,7 +119,7 @@ make all rates zero
 function reset!(hop_rates::AbstractHopRates)
     hop_rates.rates .= zero(eltype(hop_rates.rates))
     hop_rates.sum_rates .= zero(eltype(hop_rates.sum_rates))
-    nothing
+    return nothing
 end
 
 """
@@ -106,8 +128,10 @@ end
 sample species to hop from site
 """
 function sample_species(hop_rates::AbstractHopRates, site, rng)
-    @inbounds linear_search((@view hop_rates.rates[:, site]),
-        rand(rng) * total_site_hop_rate(hop_rates, site))
+    return @inbounds linear_search(
+        (@view hop_rates.rates[:, site]),
+        rand(rng) * total_site_hop_rate(hop_rates, site)
+    )
 end
 
 """
@@ -135,8 +159,10 @@ end
 
 function Base.show(io::IO, ::MIME"text/plain", hop_rates::HopRatesGraphDs)
     num_specs, num_sites = size(hop_rates.rates)
-    println(io,
-        "HopRates with $num_specs species and $num_sites sites. \nHopping constants of form D_{s} where s is species.")
+    return println(
+        io,
+        "HopRates with $num_specs species and $num_sites sites. \nHopping constants of form D_{s} where s is species."
+    )
 end
 
 """
@@ -146,18 +172,18 @@ initializes HopRatesGraphDs with zero rates
 """
 function HopRatesGraphDs(hopping_constants::Vector{F}, num_nodes) where {F <: Number}
     rates = zeros(F, length(hopping_constants), num_nodes)
-    HopRatesGraphDs{F}(hopping_constants, rates, zeros(F, size(rates, 2)))
+    return HopRatesGraphDs{F}(hopping_constants, rates, zeros(F, size(rates, 2)))
 end
 
 function sample_target_site(hop_rates::HopRatesGraphDs, site, species, rng, spatial_system)
-    rand_nbr(rng, spatial_system, site)
+    return rand_nbr(rng, spatial_system, site)
 end
 
 """
 return hopping rate of species at site
 """
 function evalhoprate(hop_rates::HopRatesGraphDs, u, species, site, spatial_system)
-    @inbounds u[species, site] * hop_rates.hopping_constants[species] * outdegree(spatial_system, site)
+    return @inbounds u[species, site] * hop_rates.hopping_constants[species] * outdegree(spatial_system, site)
 end
 
 ############## hopping rates of form D_{s,i} ################
@@ -174,8 +200,10 @@ end
 
 function Base.show(io::IO, ::MIME"text/plain", hop_rates::HopRatesGraphDsi)
     num_specs, num_sites = size(hop_rates.rates)
-    println(io,
-        "HopRates with $num_specs species and $num_sites sites. \nHopping constants of form D_{s,i} where s is species, and i is source.")
+    return println(
+        io,
+        "HopRates with $num_specs species and $num_sites sites. \nHopping constants of form D_{s,i} where s is species, and i is source."
+    )
 end
 
 """
@@ -185,18 +213,18 @@ initializes HopRatesGraphDsi with zero rates
 """
 function HopRatesGraphDsi(hopping_constants::Matrix{F}) where {F <: Number}
     rates = zeros(F, size(hopping_constants))
-    HopRatesGraphDsi{F}(hopping_constants, rates, zeros(F, size(rates, 2)))
+    return HopRatesGraphDsi{F}(hopping_constants, rates, zeros(F, size(rates, 2)))
 end
 
 function sample_target_site(hop_rates::HopRatesGraphDsi, site, species, rng, spatial_system)
-    rand_nbr(rng, spatial_system, site)
+    return rand_nbr(rng, spatial_system, site)
 end
 
 """
 return hopping rate of species at site
 """
 function evalhoprate(hop_rates::HopRatesGraphDsi, u, species, site, spatial_system)
-    @inbounds u[species, site] * hop_rates.hopping_constants[species, site] * outdegree(spatial_system, site)
+    return @inbounds u[species, site] * hop_rates.hopping_constants[species, site] * outdegree(spatial_system, site)
 end
 
 ############## hopping rates of form D_{s,i,j} ################
@@ -213,8 +241,10 @@ end
 
 function Base.show(io::IO, ::MIME"text/plain", hop_rates::HopRatesGraphDsij)
     num_specs, num_sites = size(hop_rates.rates)
-    println(io,
-        "HopRates with $num_specs species and $num_sites sites. \nHopping constants of form D_{s,i,j} where s is species, i is source and j is destination.")
+    return println(
+        io,
+        "HopRates with $num_specs species and $num_sites sites. \nHopping constants of form D_{s,i,j} where s is species, i is source and j is destination."
+    )
 end
 
 """
@@ -222,23 +252,27 @@ end
 
 initializes HopRates with zero rates
 """
-function HopRatesGraphDsij(hopping_constants::Matrix{Vector{F}};
-        do_cumsum = true) where {F <: Number}
+function HopRatesGraphDsij(
+        hopping_constants::Matrix{Vector{F}};
+        do_cumsum = true
+    ) where {F <: Number}
     do_cumsum && (hopping_constants = map(cumsum, hopping_constants))
     rates = zeros(F, size(hopping_constants))
     sum_rates = zeros(F, size(rates, 2))
-    HopRatesGraphDsij{F}(hopping_constants, rates, sum_rates)
+    return HopRatesGraphDsij{F}(hopping_constants, rates, sum_rates)
 end
 
-function sample_target_site(hop_rates::HopRatesGraphDsij, site, species, rng,
-        spatial_system)
+function sample_target_site(
+        hop_rates::HopRatesGraphDsij, site, species, rng,
+        spatial_system
+    )
     @inbounds cum_hop_consts = hop_rates.hop_const_cumulative_sums[species, site]
     @inbounds n = searchsortedfirst(cum_hop_consts, rand(rng) * cum_hop_consts[end])
     return nth_nbr(spatial_system, site, n)
 end
 
 function evalhoprate(hop_rates::HopRatesGraphDsij, u, species, site, spatial_system)
-    @inbounds u[species, site] * hop_rates.hop_const_cumulative_sums[species, site][end]
+    return @inbounds u[species, site] * hop_rates.hop_const_cumulative_sums[species, site][end]
 end
 
 #################  hopping rates of form L_{s,i,j} optimized for cartesian grid  ######################
@@ -258,8 +292,10 @@ end
 
 function Base.show(io::IO, ::MIME"text/plain", hop_rates::HopRatesGridDsij)
     num_specs, num_sites = size(hop_rates.rates)
-    println(io,
-        "HopRates with $num_specs species and $num_sites sites, optimized for CartesianGrid. \nHopping constants of form L_{s,i,j} where s is species, i is source and j is destination.")
+    return println(
+        io,
+        "HopRates with $num_specs species and $num_sites sites, optimized for CartesianGrid. \nHopping constants of form L_{s,i,j} where s is species, i is source and j is destination."
+    )
 end
 
 """
@@ -267,24 +303,28 @@ end
 
 initializes HopRates with zero rates
 """
-function HopRatesGridDsij(hopping_constants::Array{F, 3};
-        do_cumsum = true) where {F <: Number}
+function HopRatesGridDsij(
+        hopping_constants::Array{F, 3};
+        do_cumsum = true
+    ) where {F <: Number}
     do_cumsum && (hopping_constants = mapslices(cumsum, hopping_constants, dims = 1))
     rates = zeros(F, size(hopping_constants)[2:3])
     sum_rates = zeros(F, size(rates, 2))
-    HopRatesGridDsij{F}(hopping_constants, rates, sum_rates)
+    return HopRatesGridDsij{F}(hopping_constants, rates, sum_rates)
 end
 
 function HopRatesGridDsij(hopping_constants::Matrix{Vector{F}}, grid) where {F <: Number}
-    new_hopping_constants = Array{F, 3}(undef, 2 * dimension(grid),
-        size(hopping_constants)...)
+    new_hopping_constants = Array{F, 3}(
+        undef, 2 * dimension(grid),
+        size(hopping_constants)...
+    )
     for ci in CartesianIndices(hopping_constants)
         species, site = Tuple(ci)
         nb_constants = @view new_hopping_constants[:, species, site]
         pad_hop_vec!(nb_constants, grid, site, hopping_constants[ci])
         cumsum!(nb_constants, nb_constants)
     end
-    HopRatesGridDsij(new_hopping_constants, do_cumsum = false)
+    return HopRatesGridDsij(new_hopping_constants, do_cumsum = false)
 end
 
 function sample_target_site(hop_rates::HopRatesGridDsij, site, species, rng, grid)
@@ -294,7 +334,7 @@ function sample_target_site(hop_rates::HopRatesGridDsij, site, species, rng, gri
 end
 
 function evalhoprate(hop_rates::HopRatesGridDsij, u, species, site, spatial_system)
-    @inbounds u[species, site] * hop_rates.hop_const_cumulative_sums[end, species, site]
+    return @inbounds u[species, site] * hop_rates.hop_const_cumulative_sums[end, species, site]
 end
 
 ############## hopping rates of form D_s * L_{i,j} ################
@@ -314,10 +354,12 @@ end
 
 function Base.show(io::IO, ::MIME"text/plain", hop_rates::HopRatesGraphDsLij)
     num_specs,
-    num_sites = length(hop_rates.species_hop_constants),
-    length(hop_rates.hop_const_cumulative_sums)
-    println(io,
-        "HopRates with $num_specs species and $num_sites sites. \nHopping constants of form D_s * L_{i,j} where s is species, i is source and j is destination.")
+        num_sites = length(hop_rates.species_hop_constants),
+        length(hop_rates.hop_const_cumulative_sums)
+    return println(
+        io,
+        "HopRates with $num_specs species and $num_sites sites. \nHopping constants of form D_s * L_{i,j} where s is species, i is source and j is destination."
+    )
 end
 
 """
@@ -325,24 +367,28 @@ end
 
 initializes HopRates with zero rates
 """
-function HopRatesGraphDsLij(species_hop_constants::Vector{F},
+function HopRatesGraphDsLij(
+        species_hop_constants::Vector{F},
         site_hop_constants::Vector{Vector{F}};
-        do_cumsum = true) where {F <: Number}
+        do_cumsum = true
+    ) where {F <: Number}
     do_cumsum && (site_hop_constants = map(cumsum, site_hop_constants))
     rates = zeros(F, length(species_hop_constants), length(site_hop_constants))
     sum_rates = zeros(size(rates, 2))
-    HopRatesGraphDsLij{F}(species_hop_constants, site_hop_constants, rates, sum_rates)
+    return HopRatesGraphDsLij{F}(species_hop_constants, site_hop_constants, rates, sum_rates)
 end
 
-function sample_target_site(hop_rates::HopRatesGraphDsLij, site, species, rng,
-        spatial_system)
+function sample_target_site(
+        hop_rates::HopRatesGraphDsLij, site, species, rng,
+        spatial_system
+    )
     @inbounds cum_hop_consts = hop_rates.hop_const_cumulative_sums[site]
     @inbounds n = searchsortedfirst(cum_hop_consts, rand(rng) * cum_hop_consts[end])
     return nth_nbr(spatial_system, site, n)
 end
 
 function evalhoprate(hop_rates::HopRatesGraphDsLij, u, species, site, spatial_system)
-    @inbounds u[species, site] * hop_rates.species_hop_constants[species] * hop_rates.hop_const_cumulative_sums[site][end]
+    return @inbounds u[species, site] * hop_rates.species_hop_constants[species] * hop_rates.hop_const_cumulative_sums[site][end]
 end
 
 ############## hopping rates of form D_s * L_{i,j} optimized for cartesian grid ################
@@ -362,30 +408,38 @@ end
 
 function Base.show(io::IO, ::MIME"text/plain", hop_rates::HopRatesGridDsLij)
     num_specs,
-    num_sites = length(hop_rates.species_hop_constants),
-    size(hop_rates.hop_const_cumulative_sums, 2)
-    println(io,
-        "HopRates with $num_specs species and $num_sites sites, optimized for CartesianGrid. \nHopping constants of form D_s * L_{i,j} where s is species, i is source and j is destination.")
+        num_sites = length(hop_rates.species_hop_constants),
+        size(hop_rates.hop_const_cumulative_sums, 2)
+    return println(
+        io,
+        "HopRates with $num_specs species and $num_sites sites, optimized for CartesianGrid. \nHopping constants of form D_s * L_{i,j} where s is species, i is source and j is destination."
+    )
 end
 
-function HopRatesGridDsLij(species_hop_constants::Vector{F}, site_hop_constants::Matrix{F};
-        do_cumsum = true) where {F <: Number}
+function HopRatesGridDsLij(
+        species_hop_constants::Vector{F}, site_hop_constants::Matrix{F};
+        do_cumsum = true
+    ) where {F <: Number}
     do_cumsum && (site_hop_constants = mapslices(cumsum, site_hop_constants, dims = 1))
     rates = zeros(F, length(species_hop_constants), size(site_hop_constants, 2))
     sum_rates = zeros(size(rates, 2))
-    HopRatesGridDsLij{F}(species_hop_constants, site_hop_constants, rates, sum_rates)
+    return HopRatesGridDsLij{F}(species_hop_constants, site_hop_constants, rates, sum_rates)
 end
 
-function HopRatesGridDsLij(species_hop_constants::Vector{F},
-        site_hop_constants::Vector{Vector{F}}, grid) where {F <: Number}
-    new_hopping_constants = Matrix{F}(undef, 2 * dimension(grid),
-        length(site_hop_constants))
+function HopRatesGridDsLij(
+        species_hop_constants::Vector{F},
+        site_hop_constants::Vector{Vector{F}}, grid
+    ) where {F <: Number}
+    new_hopping_constants = Matrix{F}(
+        undef, 2 * dimension(grid),
+        length(site_hop_constants)
+    )
     for site in 1:length(site_hop_constants)
         nb_constants = @view new_hopping_constants[:, site]
         pad_hop_vec!(nb_constants, grid, site, site_hop_constants[site])
         cumsum!(nb_constants, nb_constants)
     end
-    HopRatesGridDsLij(species_hop_constants, new_hopping_constants, do_cumsum = false)
+    return HopRatesGridDsLij(species_hop_constants, new_hopping_constants, do_cumsum = false)
 end
 
 function sample_target_site(hop_rates::HopRatesGridDsLij, site, species, rng, grid)
@@ -395,7 +449,7 @@ function sample_target_site(hop_rates::HopRatesGridDsLij, site, species, rng, gr
 end
 
 function evalhoprate(hop_rates::HopRatesGridDsLij, u, species, site, grid)
-    @inbounds u[species, site] * hop_rates.species_hop_constants[species] * hop_rates.hop_const_cumulative_sums[end, site]
+    return @inbounds u[species, site] * hop_rates.species_hop_constants[species] * hop_rates.hop_const_cumulative_sums[end, site]
 end
 
 ############## hopping rates of form D_{s,i} * L_{i,j} ################
@@ -415,29 +469,35 @@ end
 
 function Base.show(io::IO, ::MIME"text/plain", hop_rates::HopRatesGraphDsiLij)
     num_specs, num_sites = size(hop_rates.species_hop_constants)
-    println(io,
-        "HopRates with $num_specs species and $num_sites sites. \nHopping constants of form D_{s,i} * L_{i,j} where s is species, i is source and j is destination.")
+    return println(
+        io,
+        "HopRates with $num_specs species and $num_sites sites. \nHopping constants of form D_{s,i} * L_{i,j} where s is species, i is source and j is destination."
+    )
 end
 
-function HopRatesGraphDsiLij(species_hop_constants::Matrix{F},
+function HopRatesGraphDsiLij(
+        species_hop_constants::Matrix{F},
         site_hop_constants::Vector{Vector{F}};
-        do_cumsum = true) where {F <: Number}
+        do_cumsum = true
+    ) where {F <: Number}
     @assert size(species_hop_constants, 2) == length(site_hop_constants)
     do_cumsum && (site_hop_constants = map(cumsum, site_hop_constants))
     rates = zeros(F, length(species_hop_constants), length(site_hop_constants))
     sum_rates = zeros(size(rates, 2))
-    HopRatesGraphDsiLij{F}(species_hop_constants, site_hop_constants, rates, sum_rates)
+    return HopRatesGraphDsiLij{F}(species_hop_constants, site_hop_constants, rates, sum_rates)
 end
 
-function sample_target_site(hop_rates::HopRatesGraphDsiLij, site, species, rng,
-        spatial_system)
+function sample_target_site(
+        hop_rates::HopRatesGraphDsiLij, site, species, rng,
+        spatial_system
+    )
     @inbounds cum_hop_consts = hop_rates.hop_const_cumulative_sums[site]
     @inbounds n = searchsortedfirst(cum_hop_consts, rand(rng) * cum_hop_consts[end])
     return nth_nbr(spatial_system, site, n)
 end
 
 function evalhoprate(hop_rates::HopRatesGraphDsiLij, u, species, site, spatial_system)
-    @inbounds u[species, site] * hop_rates.species_hop_constants[species, site] * hop_rates.hop_const_cumulative_sums[site][end]
+    return @inbounds u[species, site] * hop_rates.species_hop_constants[species, site] * hop_rates.hop_const_cumulative_sums[site][end]
 end
 
 ############## hopping rates of form D_{s,i} * L_{i,j} optimized for cartesian grid ################
@@ -457,32 +517,39 @@ end
 
 function Base.show(io::IO, ::MIME"text/plain", hop_rates::HopRatesGridDsiLij)
     num_specs,
-    num_sites = length(hop_rates.species_hop_constants),
-    size(hop_rates.hop_const_cumulative_sums, 2)
-    println(io,
-        "HopRates with $num_specs species and $num_sites sites, optimized for CartesianGrid. \nHopping constants of form D_{s,i} * L_{i,j} where s is species, i is source and j is destination.")
+        num_sites = length(hop_rates.species_hop_constants),
+        size(hop_rates.hop_const_cumulative_sums, 2)
+    return println(
+        io,
+        "HopRates with $num_specs species and $num_sites sites, optimized for CartesianGrid. \nHopping constants of form D_{s,i} * L_{i,j} where s is species, i is source and j is destination."
+    )
 end
 
 function HopRatesGridDsiLij(
         species_hop_constants::Matrix{F}, site_hop_constants::Matrix{F};
-        do_cumsum = true) where {F <: Number}
+        do_cumsum = true
+    ) where {F <: Number}
     @assert size(species_hop_constants, 2) == size(site_hop_constants, 2)
     do_cumsum && (site_hop_constants = mapslices(cumsum, site_hop_constants, dims = 1))
     rates = zeros(F, size(species_hop_constants))
     sum_rates = zeros(size(rates, 2))
-    HopRatesGridDsiLij{F}(species_hop_constants, site_hop_constants, rates, sum_rates)
+    return HopRatesGridDsiLij{F}(species_hop_constants, site_hop_constants, rates, sum_rates)
 end
 
-function HopRatesGridDsiLij(species_hop_constants::Matrix{F},
-        site_hop_constants::Vector{Vector{F}}, grid) where {F <: Number}
-    new_hopping_constants = Matrix{F}(undef, 2 * dimension(grid),
-        length(site_hop_constants))
+function HopRatesGridDsiLij(
+        species_hop_constants::Matrix{F},
+        site_hop_constants::Vector{Vector{F}}, grid
+    ) where {F <: Number}
+    new_hopping_constants = Matrix{F}(
+        undef, 2 * dimension(grid),
+        length(site_hop_constants)
+    )
     for site in 1:length(site_hop_constants)
         nb_constants = @view new_hopping_constants[:, site]
         pad_hop_vec!(nb_constants, grid, site, site_hop_constants[site])
         cumsum!(nb_constants, nb_constants)
     end
-    HopRatesGridDsiLij(species_hop_constants, new_hopping_constants, do_cumsum = false)
+    return HopRatesGridDsiLij(species_hop_constants, new_hopping_constants, do_cumsum = false)
 end
 
 function sample_target_site(hop_rates::HopRatesGridDsiLij, site, species, rng, grid)
@@ -492,5 +559,5 @@ function sample_target_site(hop_rates::HopRatesGridDsiLij, site, species, rng, g
 end
 
 function evalhoprate(hop_rates::HopRatesGridDsiLij, u, species, site, grid)
-    @inbounds u[species, site] * hop_rates.species_hop_constants[species, site] * hop_rates.hop_const_cumulative_sums[end, site]
+    return @inbounds u[species, site] * hop_rates.species_hop_constants[species, site] * hop_rates.hop_const_cumulative_sums[end, site]
 end

--- a/src/spatial/reaction_rates.jl
+++ b/src/spatial/reaction_rates.jl
@@ -22,7 +22,7 @@ initializes RxRates with zero rates
 function RxRates(num_sites::Int, ma_jumps::M) where {M}
     numrxjumps = get_num_majumps(ma_jumps)
     rates = zeros(Float64, numrxjumps, num_sites)
-    RxRates{Float64, M}(rates, vec(sum(rates, dims = 1)), ma_jumps)
+    return RxRates{Float64, M}(rates, vec(sum(rates, dims = 1)), ma_jumps)
 end
 
 num_rxs(rx_rates::RxRates) = get_num_majumps(rx_rates.ma_jumps)
@@ -35,7 +35,7 @@ make all rates zero
 function reset!(rx_rates::RxRates)
     fill!(rx_rates.rates, zero(eltype(rx_rates.rates)))
     fill!(rx_rates.sum_rates, zero(eltype(rx_rates.sum_rates)))
-    nothing
+    return nothing
 end
 
 """
@@ -44,7 +44,7 @@ end
 return total reaction rate at site
 """
 function total_site_rx_rate(rx_rates::RxRates, site)
-    @inbounds rx_rates.sum_rates[site]
+    return @inbounds rx_rates.sum_rates[site]
 end
 
 """
@@ -52,19 +52,23 @@ end
 
 update rates of all reactions in rxs at site
 """
-function update_rx_rates!(rx_rates::RxRates, rxs, u::AbstractMatrix, integrator,
-        site)
+function update_rx_rates!(
+        rx_rates::RxRates, rxs, u::AbstractMatrix, integrator,
+        site
+    )
     ma_jumps = rx_rates.ma_jumps
-    @inbounds for rx in rxs
+    return @inbounds for rx in rxs
         rate = eval_massaction_rate(u, rx, ma_jumps, site)
         set_rx_rate_at_site!(rx_rates, site, rx, rate)
     end
 end
 
-function update_rx_rates!(rx_rates::RxRates, rxs, integrator,
-        site)
+function update_rx_rates!(
+        rx_rates::RxRates, rxs, integrator,
+        site
+    )
     u = integrator.u
-    update_rx_rates!(rx_rates, rxs, u, integrator, site)
+    return update_rx_rates!(rx_rates, rxs, u, integrator, site)
 end
 
 """
@@ -73,8 +77,10 @@ end
 sample a reaction at site, return reaction index
 """
 function sample_rx_at_site(rx_rates::RxRates, site, rng)
-    linear_search((@view rx_rates.rates[:, site]),
-        rand(rng) * total_site_rx_rate(rx_rates, site))
+    return linear_search(
+        (@view rx_rates.rates[:, site]),
+        rand(rng) * total_site_rx_rate(rx_rates, site)
+    )
 end
 
 # helper functions
@@ -82,17 +88,17 @@ function set_rx_rate_at_site!(rx_rates::RxRates, site, rx, rate)
     @inbounds old_rate = rx_rates.rates[rx, site]
     @inbounds rx_rates.rates[rx, site] = rate
     @inbounds rx_rates.sum_rates[site] += rate - old_rate
-    old_rate
+    return old_rate
 end
 
 function Base.show(io::IO, ::MIME"text/plain", rx_rates::RxRates)
     num_rxs, num_sites = size(rx_rates.rates)
-    println(io, "RxRates with $num_rxs reactions and $num_sites sites")
+    return println(io, "RxRates with $num_rxs reactions and $num_sites sites")
 end
 
 function eval_massaction_rate(u, rx, ma_jumps::M, site) where {M <: SpatialMassActionJump}
-    evalrxrate(u, rx, ma_jumps, site)
+    return evalrxrate(u, rx, ma_jumps, site)
 end
 function eval_massaction_rate(u, rx, ma_jumps::M, site) where {M <: MassActionJump}
-    evalrxrate((@view u[:, site]), rx, ma_jumps)
+    return evalrxrate((@view u[:, site]), rx, ma_jumps)
 end

--- a/src/spatial/spatial_massaction_jump.jl
+++ b/src/spatial/spatial_massaction_jump.jl
@@ -2,7 +2,7 @@ const AVecOrNothing = Union{AbstractVector, Nothing}
 const AMatOrNothing = Union{AbstractMatrix, Nothing}
 
 struct SpatialMassActionJump{A <: AVecOrNothing, B <: AMatOrNothing, S, U, V} <:
-       AbstractMassActionJump
+    AbstractMassActionJump
     uniform_rates::A # reactions that are uniform in space
     spatial_rates::B # reactions whose rate depends on the site
     reactant_stoch::S
@@ -12,21 +12,25 @@ struct SpatialMassActionJump{A <: AVecOrNothing, B <: AMatOrNothing, S, U, V} <:
     """
     uniform rates go first in ordering
     """
-    function SpatialMassActionJump{A, B, S, U, V}(uniform_rates::A, spatial_rates::B,
+    function SpatialMassActionJump{A, B, S, U, V}(
+            uniform_rates::A, spatial_rates::B,
             reactant_stoch::S, net_stoch::U,
             param_mapper::V, scale_rates::Bool,
             useiszero::Bool,
-            nocopy::Bool) where {A <: AVecOrNothing,
+            nocopy::Bool
+        ) where {
+            A <: AVecOrNothing,
             B <: AMatOrNothing,
-            S, U, V}
+            S, U, V,
+        }
         uniform_rates = (nocopy || isnothing(uniform_rates)) ? uniform_rates :
-                        copy(uniform_rates)
+            copy(uniform_rates)
         spatial_rates = (nocopy || isnothing(spatial_rates)) ? spatial_rates :
-                        copy(spatial_rates)
+            copy(spatial_rates)
         reactant_stoch = nocopy ? reactant_stoch : copy(reactant_stoch)
         for i in eachindex(reactant_stoch)
             if useiszero && (length(reactant_stoch[i]) == 1) &&
-               iszero(reactant_stoch[i][1][1])
+                    iszero(reactant_stoch[i][1][1])
                 reactant_stoch[i] = typeof(reactant_stoch[i])()
             end
         end
@@ -37,100 +41,152 @@ struct SpatialMassActionJump{A <: AVecOrNothing, B <: AMatOrNothing, S, U, V} <:
         if scale_rates && !isnothing(spatial_rates) && !isempty(spatial_rates)
             scalerates!(spatial_rates, reactant_stoch[(num_unif_rates + 1):end])
         end
-        new(uniform_rates, spatial_rates, reactant_stoch, net_stoch, param_mapper)
+        return new(uniform_rates, spatial_rates, reactant_stoch, net_stoch, param_mapper)
     end
 end
 
 ################ Constructors ##################
 
-function SpatialMassActionJump(urates::A, srates::B, rs::S, ns::U, pmapper::V;
+function SpatialMassActionJump(
+        urates::A, srates::B, rs::S, ns::U, pmapper::V;
         scale_rates = true, useiszero = true,
-        nocopy = false) where {A <: AVecOrNothing,
-        B <: AMatOrNothing, S, U, V}
-    SpatialMassActionJump{A, B, S, U, V}(urates, srates, rs, ns, pmapper, scale_rates,
-        useiszero, nocopy)
+        nocopy = false
+    ) where {
+        A <: AVecOrNothing,
+        B <: AMatOrNothing, S, U, V,
+    }
+    return SpatialMassActionJump{A, B, S, U, V}(
+        urates, srates, rs, ns, pmapper, scale_rates,
+        useiszero, nocopy
+    )
 end
-function SpatialMassActionJump(urates::A, srates::B, rs, ns; scale_rates = true,
+function SpatialMassActionJump(
+        urates::A, srates::B, rs, ns; scale_rates = true,
         useiszero = true,
-        nocopy = false) where {A <: AVecOrNothing,
-        B <: AMatOrNothing}
-    SpatialMassActionJump(urates, srates, rs, ns, nothing; scale_rates = scale_rates,
-        useiszero = useiszero, nocopy = nocopy)
+        nocopy = false
+    ) where {
+        A <: AVecOrNothing,
+        B <: AMatOrNothing,
+    }
+    return SpatialMassActionJump(
+        urates, srates, rs, ns, nothing; scale_rates = scale_rates,
+        useiszero = useiszero, nocopy = nocopy
+    )
 end
 
-function SpatialMassActionJump(srates::B, rs, ns, pmapper; scale_rates = true,
+function SpatialMassActionJump(
+        srates::B, rs, ns, pmapper; scale_rates = true,
         useiszero = true,
-        nocopy = false) where {B <: AMatOrNothing}
-    SpatialMassActionJump(nothing, srates, rs, ns, pmapper; scale_rates = scale_rates,
-        useiszero = useiszero, nocopy = nocopy)
+        nocopy = false
+    ) where {B <: AMatOrNothing}
+    return SpatialMassActionJump(
+        nothing, srates, rs, ns, pmapper; scale_rates = scale_rates,
+        useiszero = useiszero, nocopy = nocopy
+    )
 end
-function SpatialMassActionJump(srates::B, rs, ns; scale_rates = true, useiszero = true,
-        nocopy = false) where {B <: AMatOrNothing}
-    SpatialMassActionJump(nothing, srates, rs, ns, nothing; scale_rates = scale_rates,
-        useiszero = useiszero, nocopy = nocopy)
+function SpatialMassActionJump(
+        srates::B, rs, ns; scale_rates = true, useiszero = true,
+        nocopy = false
+    ) where {B <: AMatOrNothing}
+    return SpatialMassActionJump(
+        nothing, srates, rs, ns, nothing; scale_rates = scale_rates,
+        useiszero = useiszero, nocopy = nocopy
+    )
 end
 
-function SpatialMassActionJump(urates::A, rs, ns, pmapper; scale_rates = true,
+function SpatialMassActionJump(
+        urates::A, rs, ns, pmapper; scale_rates = true,
         useiszero = true,
-        nocopy = false) where {A <: AVecOrNothing}
-    SpatialMassActionJump(urates, nothing, rs, ns, pmapper; scale_rates = scale_rates,
-        useiszero = useiszero, nocopy = nocopy)
+        nocopy = false
+    ) where {A <: AVecOrNothing}
+    return SpatialMassActionJump(
+        urates, nothing, rs, ns, pmapper; scale_rates = scale_rates,
+        useiszero = useiszero, nocopy = nocopy
+    )
 end
-function SpatialMassActionJump(urates::A, rs, ns; scale_rates = true, useiszero = true,
-        nocopy = false) where {A <: AVecOrNothing}
-    SpatialMassActionJump(urates, nothing, rs, ns, nothing; scale_rates = scale_rates,
-        useiszero = useiszero, nocopy = nocopy)
+function SpatialMassActionJump(
+        urates::A, rs, ns; scale_rates = true, useiszero = true,
+        nocopy = false
+    ) where {A <: AVecOrNothing}
+    return SpatialMassActionJump(
+        urates, nothing, rs, ns, nothing; scale_rates = scale_rates,
+        useiszero = useiszero, nocopy = nocopy
+    )
 end
 
-function SpatialMassActionJump(ma_jumps::MassActionJump{T, S, U, V}; scale_rates = true,
-        useiszero = true, nocopy = false) where {T, S, U, V}
-    SpatialMassActionJump(ma_jumps.scaled_rates, ma_jumps.reactant_stoch,
+function SpatialMassActionJump(
+        ma_jumps::MassActionJump{T, S, U, V}; scale_rates = true,
+        useiszero = true, nocopy = false
+    ) where {T, S, U, V}
+    return SpatialMassActionJump(
+        ma_jumps.scaled_rates, ma_jumps.reactant_stoch,
         ma_jumps.net_stoch, ma_jumps.param_mapper;
-        scale_rates = scale_rates, useiszero = useiszero, nocopy = nocopy)
+        scale_rates = scale_rates, useiszero = useiszero, nocopy = nocopy
+    )
 end
 
 ##############################################
 
-function get_num_majumps(smaj::SpatialMassActionJump{
-        Nothing, Nothing, S, U, V}) where
-        {S, U, V}
-    0
+function get_num_majumps(
+        smaj::SpatialMassActionJump{
+            Nothing, Nothing, S, U, V,
+        }
+    ) where
+    {S, U, V}
+    return 0
 end
-function get_num_majumps(smaj::SpatialMassActionJump{
-        Nothing, B, S, U, V}) where
-        {B, S, U, V}
-    size(smaj.spatial_rates, 1)
+function get_num_majumps(
+        smaj::SpatialMassActionJump{
+            Nothing, B, S, U, V,
+        }
+    ) where
+    {B, S, U, V}
+    return size(smaj.spatial_rates, 1)
 end
-function get_num_majumps(smaj::SpatialMassActionJump{
-        A, Nothing, S, U, V}) where
-        {A, S, U, V}
-    length(smaj.uniform_rates)
+function get_num_majumps(
+        smaj::SpatialMassActionJump{
+            A, Nothing, S, U, V,
+        }
+    ) where
+    {A, S, U, V}
+    return length(smaj.uniform_rates)
 end
-function get_num_majumps(smaj::SpatialMassActionJump{
-        A, B, S, U, V}) where
-        {A <: AbstractVector, B <: AbstractMatrix, S, U, V}
-    length(smaj.uniform_rates) + size(smaj.spatial_rates, 1)
+function get_num_majumps(
+        smaj::SpatialMassActionJump{
+            A, B, S, U, V,
+        }
+    ) where
+    {A <: AbstractVector, B <: AbstractMatrix, S, U, V}
+    return length(smaj.uniform_rates) + size(smaj.spatial_rates, 1)
 end
 using_params(smaj::SpatialMassActionJump) = false
 
-function rate_at_site(rx, site,
-        smaj::SpatialMassActionJump{Nothing, B, S, U, V}) where {B, S, U, V}
-    smaj.spatial_rates[rx, site]
+function rate_at_site(
+        rx, site,
+        smaj::SpatialMassActionJump{Nothing, B, S, U, V}
+    ) where {B, S, U, V}
+    return smaj.spatial_rates[rx, site]
 end
-function rate_at_site(rx, site,
-        smaj::SpatialMassActionJump{A, Nothing, S, U, V}) where {A, S, U, V}
-    smaj.uniform_rates[rx]
+function rate_at_site(
+        rx, site,
+        smaj::SpatialMassActionJump{A, Nothing, S, U, V}
+    ) where {A, S, U, V}
+    return smaj.uniform_rates[rx]
 end
-function rate_at_site(rx, site,
-        smaj::SpatialMassActionJump{A, B, S, U, V}) where
-        {A <: AbstractVector, B <: AbstractMatrix, S, U, V}
+function rate_at_site(
+        rx, site,
+        smaj::SpatialMassActionJump{A, B, S, U, V}
+    ) where
+    {A <: AbstractVector, B <: AbstractMatrix, S, U, V}
     num_unif_rxs = length(smaj.uniform_rates)
-    rx <= num_unif_rxs ? smaj.uniform_rates[rx] :
-    smaj.spatial_rates[rx - num_unif_rxs, site]
+    return rx <= num_unif_rxs ? smaj.uniform_rates[rx] :
+        smaj.spatial_rates[rx - num_unif_rxs, site]
 end
 
-function evalrxrate(speciesmat::AbstractMatrix{T}, rxidx::S, majump::SpatialMassActionJump,
-        site::Int) where {T, S}
+function evalrxrate(
+        speciesmat::AbstractMatrix{T}, rxidx::S, majump::SpatialMassActionJump,
+        site::Int
+    ) where {T, S}
     val = one(T)
     @inbounds for specstoch in majump.reactant_stoch[rxidx]
         specpop = speciesmat[specstoch[1], site]

--- a/src/spatial/topology.jl
+++ b/src/spatial/topology.jl
@@ -15,7 +15,7 @@ const offsets_2D = [
     CartesianIndex(0, -1),
     CartesianIndex(-1, 0),
     CartesianIndex(1, 0),
-    CartesianIndex(0, 1)
+    CartesianIndex(0, 1),
 ]
 const offsets_3D = [
     CartesianIndex(0, 0, -1),
@@ -23,7 +23,7 @@ const offsets_3D = [
     CartesianIndex(-1, 0, 0),
     CartesianIndex(1, 0, 0),
     CartesianIndex(0, 1, 0),
-    CartesianIndex(0, 0, 1)
+    CartesianIndex(0, 0, 1),
 ]
 
 """
@@ -61,7 +61,7 @@ function nth_nbr(grid, site, n)
     CI = grid.CI
     offsets = grid.offsets
     @inbounds I = CI[site]
-    @inbounds for off in offsets
+    return @inbounds for off in offsets
         nb = I + off
         if nb in CI
             n -= 1
@@ -79,7 +79,7 @@ function neighbors(grid, site)
     CI = grid.CI
     LI = grid.LI
     I = CI[site]
-    Iterators.map(off -> LI[off + I], Iterators.filter(off -> off + I in CI, grid.offsets))
+    return Iterators.map(off -> LI[off + I], Iterators.filter(off -> off + I in CI, grid.offsets))
 end
 
 """
@@ -97,7 +97,7 @@ function pad_hop_vec!(to_pad::AbstractVector, grid, site, hop_vec::AbstractVecto
             to_pad[i] = zero(eltype(to_pad))
         end
     end
-    to_pad
+    return to_pad
 end
 
 CartesianGrid(dims) = CartesianGridRej(dims) # use CartesianGridRej by default
@@ -127,11 +127,11 @@ function CartesianGridRej(dims::Tuple)
     LI = LinearIndices(dims)
     offsets = potential_offsets(dim)
     nums_neighbors = Int8[count(x -> x + CI[site] in CI, offsets) for site in 1:prod(dims)]
-    CartesianGridRej(dims, nums_neighbors, CI, LI, offsets)
+    return CartesianGridRej(dims, nums_neighbors, CI, LI, offsets)
 end
 CartesianGridRej(dims) = CartesianGridRej(Tuple(dims))
 function CartesianGridRej(dimension, linear_size::Int)
-    CartesianGridRej([linear_size for i in 1:dimension])
+    return CartesianGridRej([linear_size for i in 1:dimension])
 end
 function rand_nbr(rng, grid::CartesianGridRej, site::Int)
     CI = grid.CI
@@ -141,9 +141,12 @@ function rand_nbr(rng, grid::CartesianGridRej, site::Int)
         @inbounds nb = rand(rng, offsets) + I
         @inbounds nb in CI && return grid.LI[nb]
     end
+    return
 end
 
-function Base.show(io::IO, ::MIME"text/plain",
-        grid::CartesianGridRej)
-    println(io, "A Cartesian grid with dimensions $(grid.dims)")
+function Base.show(
+        io::IO, ::MIME"text/plain",
+        grid::CartesianGridRej
+    )
+    return println(io, "A Cartesian grid with dimensions $(grid.dims)")
 end

--- a/src/spatial/utils.jl
+++ b/src/spatial/utils.jl
@@ -17,8 +17,10 @@ struct SpatialJump{J}
 end
 
 function Base.show(io::IO, ::MIME"text/plain", jump::SpatialJump)
-    println(io,
-        "SpatialJump with source $(jump.src), destination $(jump.dst) and index $(jump.jidx).")
+    return println(
+        io,
+        "SpatialJump with source $(jump.src), destination $(jump.dst) and index $(jump.jidx)."
+    )
 end
 
 ######################## helper routines for all spatial SSAs ########################
@@ -29,25 +31,27 @@ sample jump at site with direct method
 """
 function sample_jump_direct(p, site)
     if rand(p.rng) * (total_site_rate(p.rx_rates, p.hop_rates, site)) <
-       total_site_rx_rate(p.rx_rates, site)
+            total_site_rx_rate(p.rx_rates, site)
         rx = sample_rx_at_site(p.rx_rates, site, p.rng)
         return SpatialJump(site, rx + p.numspecies, site)
     else
         species_to_diffuse,
-        target_site = sample_hop_at_site(p.hop_rates, site, p.rng,
-            p.spatial_system)
+            target_site = sample_hop_at_site(
+            p.hop_rates, site, p.rng,
+            p.spatial_system
+        )
         return SpatialJump(site, species_to_diffuse, target_site)
     end
 end
 
 function total_site_rate(rx_rates::RxRates, hop_rates::AbstractHopRates, site)
-    total_site_hop_rate(hop_rates, site) + total_site_rx_rate(rx_rates, site)
+    return total_site_hop_rate(hop_rates, site) + total_site_rx_rate(rx_rates, site)
 end
 
 function update_rates_after_reaction!(p, integrator, site, reaction_id)
     u = integrator.u
     update_rx_rates!(p.rx_rates, p.dep_gr[reaction_id], integrator, site)
-    update_hop_rates!(p.hop_rates, p.jumptovars_map[reaction_id], u, site, p.spatial_system)
+    return update_hop_rates!(p.hop_rates, p.jumptovars_map[reaction_id], u, site, p.spatial_system)
 end
 
 function update_rates_after_hop!(p, integrator, source_site, target_site, species)
@@ -56,7 +60,7 @@ function update_rates_after_hop!(p, integrator, source_site, target_site, specie
     update_hop_rate!(p.hop_rates, species, u, source_site, p.spatial_system)
 
     update_rx_rates!(p.rx_rates, p.vartojumps_map[species], integrator, target_site)
-    update_hop_rate!(p.hop_rates, species, u, target_site, p.spatial_system)
+    return update_hop_rate!(p.hop_rates, species, u, target_site, p.spatial_system)
 end
 
 """
@@ -70,12 +74,14 @@ function update_state!(p, integrator)
         execute_hop!(integrator, jump.src, jump.dst, jump.jidx)
     else
         rx_index = reaction_id_from_jump(p, jump)
-        @inbounds executerx!((@view integrator.u[:, jump.src]), rx_index,
-            p.rx_rates.ma_jumps)
+        @inbounds executerx!(
+            (@view integrator.u[:, jump.src]), rx_index,
+            p.rx_rates.ma_jumps
+        )
     end
     # save jump that was just executed
     p.prev_jump = jump
-    nothing
+    return nothing
 end
 
 """
@@ -84,7 +90,7 @@ end
 true if jump is a hop
 """
 function is_hop(p, jump)
-    jump.jidx <= p.numspecies
+    return jump.jidx <= p.numspecies
 end
 
 """
@@ -94,7 +100,7 @@ documentation
 """
 function execute_hop!(integrator, source_site, target_site, species)
     @inbounds integrator.u[species, source_site] -= 1
-    @inbounds integrator.u[species, target_site] += 1
+    return @inbounds integrator.u[species, target_site] += 1
 end
 
 """
@@ -103,5 +109,5 @@ end
 return reaction id by subtracting the number of hops
 """
 function reaction_id_from_jump(p, jump)
-    jump.jidx - p.numspecies
+    return jump.jidx - p.numspecies
 end

--- a/test/allocations.jl
+++ b/test/allocations.jl
@@ -14,7 +14,7 @@ let
     function affect1!(integrator)
         integrator.u[1] -= 1         # S -> S - 1
         integrator.u[2] += 1         # I -> I + 1
-        nothing
+        return nothing
     end
     jump = ConstantRateJump(rate1, affect1!)
 
@@ -22,7 +22,7 @@ let
     function affect2!(integrator)
         integrator.u[2] -= 1        # I -> I - 1
         integrator.u[3] += 1        # R -> R + 1
-        nothing
+        return nothing
     end
     jump2 = ConstantRateJump(rate2, affect2!)
 
@@ -55,8 +55,10 @@ let
         return (η / K) * (K - (X + Y))
     end
 
-    function makeprob(; T = 100.0, alg = Direct(), save_positions = (false, false),
-            graphkwargs = (;), rng)
+    function makeprob(;
+            T = 100.0, alg = Direct(), save_positions = (false, false),
+            graphkwargs = (;), rng
+        )
         r1(u, p, t) = rate(p[1], u[1], u[2], p[2]) * u[1]
         r2(u, p, t) = rate(p[1], u[2], u[1], p[2]) * u[2]
         r3(u, p, t) = p[3] * u[1]
@@ -69,24 +71,26 @@ let
         aff4!(integrator) = integrator.u[2] -= 1
         function aff5!(integrator)
             integrator.u[1] -= 1
-            integrator.u[2] += 1
+            return integrator.u[2] += 1
         end
         function aff6!(integrator)
             integrator.u[1] += 1
-            integrator.u[2] -= 1
+            return integrator.u[2] -= 1
         end
         #    η    K    μ    γ     ρ
-        p = (1.0, 1e4, 0.1, 1e-4, 0.01)
+        p = (1.0, 1.0e4, 0.1, 1.0e-4, 0.01)
         u0 = [1000, 10]
         tspan = (0.0, T)
 
         dprob = DiscreteProblem(u0, tspan, p)
-        jprob = JumpProblem(dprob, alg,
+        jprob = JumpProblem(
+            dprob, alg,
             ConstantRateJump(r1, aff1!), ConstantRateJump(r2, aff2!),
             ConstantRateJump(r3, aff3!),
             ConstantRateJump(r4, aff4!), ConstantRateJump(r5, aff5!),
             ConstantRateJump(r6, aff6!);
-            save_positions, rng, graphkwargs...)
+            save_positions, rng, graphkwargs...
+        )
         return jprob
     end
 

--- a/test/bimolerx_test.jl
+++ b/test/bimolerx_test.jl
@@ -40,14 +40,14 @@ reactstoch = [
     [2 => 1],
     [1 => 1, 2 => 1],
     [3 => 1],
-    [3 => 3]
+    [3 => 3],
 ]
 netstoch = [
     [1 => -2, 2 => 1],
     [1 => 2, 2 => -1],
     [1 => -1, 2 => -1, 3 => 1],
     [1 => 1, 2 => 1, 3 => -1],
-    [1 => 3, 3 => -3]
+    [1 => 3, 3 => -3],
 ]
 rates = [1.0, 2.0, 0.5, 0.75, 0.25]
 spec_to_dep_jumps = [[1, 3], [2, 3], [4, 5]]
@@ -61,7 +61,7 @@ function runSSAs(jump_prob; use_stepper = true)
         sol = use_stepper ? solve(jump_prob, SSAStepper()) : solve(jump_prob)
         Psamp[i] = sol[1, end]
     end
-    mean(Psamp)
+    return mean(Psamp)
 end
 
 # TESTING:
@@ -70,9 +70,11 @@ prob = DiscreteProblem(u0, (0.0, tf), rates)
 # plotting one full trajectory
 if doplot
     for alg in SSAalgs
-        local jump_prob = JumpProblem(prob, alg, majumps,
+        local jump_prob = JumpProblem(
+            prob, alg, majumps,
             vartojumps_map = spec_to_dep_jumps,
-            jumptovars_map = jump_to_dep_specs, rng = rng)
+            jumptovars_map = jump_to_dep_specs, rng = rng
+        )
         local sol = solve(jump_prob, SSAStepper())
         local plothand = plot(sol, seriestype = :steppost, reuse = false)
         display(plothand)
@@ -82,13 +84,17 @@ end
 # test the means
 if dotestmean
     for (i, alg) in enumerate(SSAalgs)
-        local jump_prob = JumpProblem(prob, alg, majumps, save_positions = (false, false),
+        local jump_prob = JumpProblem(
+            prob, alg, majumps, save_positions = (false, false),
             vartojumps_map = spec_to_dep_jumps,
-            jumptovars_map = jump_to_dep_specs, rng = rng)
+            jumptovars_map = jump_to_dep_specs, rng = rng
+        )
         means = runSSAs(jump_prob)
         relerr = abs(means - expected_avg) / expected_avg
-        doprintmeans && println("Mean from method: ", typeof(alg), " is = ", means,
-            ", rel err = ", relerr)
+        doprintmeans && println(
+            "Mean from method: ", typeof(alg), " is = ", means,
+            ", rel err = ", relerr
+        )
         @test abs(means - expected_avg) < reltol * expected_avg
 
         # test not specifying SSAStepper
@@ -105,14 +111,18 @@ if dotestmean
         push!(majump_vec, MassActionJump(rates[i], reactstoch[i], netstoch[i]))
     end
     jset = JumpSet((), (), nothing, majump_vec)
-    jump_prob = JumpProblem(prob, Direct(), jset, save_positions = (false, false),
+    jump_prob = JumpProblem(
+        prob, Direct(), jset, save_positions = (false, false),
         vartojumps_map = spec_to_dep_jumps,
-        jumptovars_map = jump_to_dep_specs, rng = rng)
+        jumptovars_map = jump_to_dep_specs, rng = rng
+    )
     meanval = runSSAs(jump_prob)
     relerr = abs(meanval - expected_avg) / expected_avg
     if doprintmeans
-        println("Using individual MassActionJumps; Mean from method: ", typeof(Direct()),
-            " is = ", meanval, ", rel err = ", relerr)
+        println(
+            "Using individual MassActionJumps; Mean from method: ", typeof(Direct()),
+            " is = ", meanval, ", rel err = ", relerr
+        )
     end
     @test abs(meanval - expected_avg) < reltol * expected_avg
 end

--- a/test/bracketing.jl
+++ b/test/bracketing.jl
@@ -8,7 +8,7 @@ bd = BracketData(fluctuation_rate, threshold, Δu)
 
 ### Getters ###
 species_index = 1
-# The fluctuation rate δ corresponds to species brackets (1-δ)*u, (1+δ)*u. So 0 < δ < 1. 
+# The fluctuation rate δ corresponds to species brackets (1-δ)*u, (1+δ)*u. So 0 < δ < 1.
 @test 0 < JP.getfr(bd, species_index) < 1
 # If u < threshold, then the brackets are (max(u-Δu, 0), u+Δu). So 0 <= threshold and 0 <= Δu.
 @test 0 <= JP.gettv(bd, species_index)
@@ -23,8 +23,8 @@ species_index = 2
 @test JP.get_spec_brackets(bd, species_index, u)[1] == u[2] - Δu
 @test JP.get_spec_brackets(bd, species_index, u)[2] == u[2] + Δu
 species_index = 3
-@test JP.get_spec_brackets(bd, species_index, u)[1]≈u[3] * (1 - fluctuation_rate) atol=1
-@test JP.get_spec_brackets(bd, species_index, u)[2]≈u[3] * (1 + fluctuation_rate) atol=1
+@test JP.get_spec_brackets(bd, species_index, u)[1] ≈ u[3] * (1 - fluctuation_rate) atol = 1
+@test JP.get_spec_brackets(bd, species_index, u)[2] ≈ u[3] * (1 + fluctuation_rate) atol = 1
 
 ### Reaction rate brackets ###
 ulow = [2]
@@ -34,8 +34,10 @@ uhigh = [10]
 majump_rates = [0.1] # death at rate 0.1
 reactstoch = [[1 => 1]]
 netstoch = [[1 => -1]]
-majump = MassActionJump(majump_rates, reactstoch,
-    netstoch)
+majump = MassActionJump(
+    majump_rates, reactstoch,
+    netstoch
+)
 reaction_index = 1
 @test JP.get_majump_brackets(ulow, uhigh, reaction_index, majump)[1] == majump_rates[1] * ulow[1] # low
 @test JP.get_majump_brackets(ulow, uhigh, reaction_index, majump)[2] == majump_rates[1] * uhigh[1] # high
@@ -49,7 +51,7 @@ t = 0.0
 
 ### Aggregator ###
 mutable struct DummyAggregator{T, M, R, BD} <:
-               JP.AbstractSSAJumpAggregator{T, M, R, Nothing, Nothing}
+    JP.AbstractSSAJumpAggregator{T, M, R, Nothing, Nothing}
     ulow::Vector{Int}
     uhigh::Vector{Int}
     cur_rate_low::Vector{T}
@@ -67,8 +69,8 @@ p = DummyAggregator([0], [0], cur_rate_low, cur_rate_high, sum_rate, majump, [ra
 
 u = [100]
 JP.update_u_brackets!(p, u)
-@test p.ulow[1]≈u[1] * (1 - fluctuation_rate) atol=1
-@test p.uhigh[1]≈u[1] * (1 + fluctuation_rate) atol=1
+@test p.ulow[1] ≈ u[1] * (1 - fluctuation_rate) atol = 1
+@test p.uhigh[1] ≈ u[1] * (1 + fluctuation_rate) atol = 1
 
 reaction_index = 1
 @test JP.get_jump_brackets(reaction_index, p, params, t)[1] == majump_rates[1] * p.ulow[1]
@@ -79,10 +81,10 @@ reaction_index = 2
 
 p = DummyAggregator([0], [0], cur_rate_low, cur_rate_high, sum_rate, majump, [rate], bd)
 JP.set_bracketing!(p, u, params, t)
-@test p.ulow[1]≈u[1] * (1 - fluctuation_rate) atol=1
-@test p.uhigh[1]≈u[1] * (1 + fluctuation_rate) atol=1
-@test p.cur_rate_low[1]≈majump_rates[1] * u[1] * (1 - fluctuation_rate) atol=1
-@test p.cur_rate_high[1]≈majump_rates[1] * u[1] * (1 + fluctuation_rate) atol=1
+@test p.ulow[1] ≈ u[1] * (1 - fluctuation_rate) atol = 1
+@test p.uhigh[1] ≈ u[1] * (1 + fluctuation_rate) atol = 1
+@test p.cur_rate_low[1] ≈ majump_rates[1] * u[1] * (1 - fluctuation_rate) atol = 1
+@test p.cur_rate_high[1] ≈ majump_rates[1] * u[1] * (1 + fluctuation_rate) atol = 1
 @test p.cur_rate_low[2] == rate(p.uhigh, params, t)
 @test p.cur_rate_high[2] == rate(p.ulow, params, t)
 @test p.sum_rate ≈ sum(p.cur_rate_high)

--- a/test/constant_rate.jl
+++ b/test/constant_rate.jl
@@ -5,13 +5,13 @@ rng = StableRNG(12345)
 
 rate = (u, p, t) -> u
 affect! = function (integrator)
-    integrator.u += 1
+    return integrator.u += 1
 end
 jump = ConstantRateJump(rate, affect!)
 
 rate = (u, p, t) -> 0.5u
 affect! = function (integrator)
-    integrator.u -= 1
+    return integrator.u -= 1
 end
 jump2 = ConstantRateJump(rate, affect!)
 

--- a/test/degenerate_rx_cases.jl
+++ b/test/degenerate_rx_cases.jl
@@ -84,7 +84,7 @@ ns = [1 => 1]
 jump = MassActionJump(rate, rs, ns)
 ratefun = (u, p, t) -> 2.0 * u[1]
 affect! = function (integrator)
-    integrator.u[1] -= 1
+    return integrator.u[1] -= 1
 end
 jump2 = ConstantRateJump(ratefun, affect!)
 if doplot
@@ -93,7 +93,7 @@ end
 
 dep_graph = [
     [1, 2],
-    [1, 2]
+    [1, 2],
 ]
 spec_to_dep_jumps = [[2]]
 jump_to_dep_specs = [[1], [1]]
@@ -128,12 +128,16 @@ maj1 = MassActionJump(rs1, ns1; param_idxs = 1)
 maj2 = MassActionJump(rs2, ns2; param_idxs = 2)
 js = JumpSet(maj1, maj2)
 maj = MassActionJump([rs1, rs2], [ns1, ns2]; param_idxs = [1, 2])
-@test all(getfield(maj, fn) == getfield(js.massaction_jump, fn)
-for fn in [:scaled_rates, :reactant_stoch, :net_stoch])
+@test all(
+    getfield(maj, fn) == getfield(js.massaction_jump, fn)
+        for fn in [:scaled_rates, :reactant_stoch, :net_stoch]
+)
 @test all(maj.param_mapper.param_idxs .== js.massaction_jump.param_mapper.param_idxs)
 maj1 = MassActionJump([rs1], [ns1]; param_idxs = [1])
 maj2 = MassActionJump([rs2], [ns2]; param_idxs = [2])
 js = JumpSet(maj1, maj2)
-@test all(getfield(maj, fn) == getfield(js.massaction_jump, fn)
-for fn in [:scaled_rates, :reactant_stoch, :net_stoch])
+@test all(
+    getfield(maj, fn) == getfield(js.massaction_jump, fn)
+        for fn in [:scaled_rates, :reactant_stoch, :net_stoch]
+)
 @test all(maj.param_mapper.param_idxs .== js.massaction_jump.param_mapper.param_idxs)

--- a/test/extended_jump_array.jl
+++ b/test/extended_jump_array.jl
@@ -5,16 +5,22 @@ using StableRNGs
 rng = StableRNG(123)
 
 # Check that the new broadcast norm gives the same result as the old one
-rand_array = ExtendedJumpArray{Float64, 1, Vector{Float64}, Vector{Float64}}(rand(rng, 5),
-    rand(rng, 2))
+rand_array = ExtendedJumpArray{Float64, 1, Vector{Float64}, Vector{Float64}}(
+    rand(rng, 5),
+    rand(rng, 2)
+)
 old_norm = Base.FastMath.sqrt_fast(DiffEqBase.UNITLESS_ABS2(rand_array) / max(DiffEqBase.recursive_length(rand_array), 1))
 new_norm = DiffEqBase.ODE_DEFAULT_NORM(rand_array, 0.0)
 @test old_norm ≈ new_norm
 
 # Check for an ExtendedJumpArray where the types differ (Float64/Int64)
-rand_array = ExtendedJumpArray{Float64, 1, Vector{Float64}, Vector{Int64}}(rand(rng, 5),
-    rand(rng, 1:1000,
-        2))
+rand_array = ExtendedJumpArray{Float64, 1, Vector{Float64}, Vector{Int64}}(
+    rand(rng, 5),
+    rand(
+        rng, 1:1000,
+        2
+    )
+)
 old_norm = Base.FastMath.sqrt_fast(DiffEqBase.UNITLESS_ABS2(rand_array) / max(DiffEqBase.recursive_length(rand_array), 1))
 new_norm = DiffEqBase.ODE_DEFAULT_NORM(rand_array, 0.0)
 @test old_norm ≈ new_norm
@@ -41,7 +47,7 @@ bc_out .= 3.14 .* bc_eja_1 + 2.7 .* bc_eja_2
 
 # Test that mismatched arrays cannot be broadcasted
 bc_mismatch = ExtendedJumpArray(rand(rng, 8), rand(rng, 4))
-@test_throws DimensionMismatch bc_mismatch+bc_eja_1
+@test_throws DimensionMismatch bc_mismatch + bc_eja_1
 @test_throws DimensionMismatch bc_mismatch .+ bc_eja_1
 
 # Test that datatype mixing persists through broadcasting
@@ -63,7 +69,7 @@ out_result .= bc_dtype_1 .+ bc_dtype_2 .* 2
 oop_test_rate(u, p, t) = exp(t)
 function oop_test_affect!(integrator)
     integrator.u[1] += 1
-    nothing
+    return nothing
 end
 oop_test_jump = VariableRateJump(oop_test_rate, oop_test_affect!)
 
@@ -109,7 +115,7 @@ let
 
     function f!(du, u, p, t)
         du .= 0
-        nothing
+        return nothing
     end
     u₀ = [0, 0]
     oprob = ODEProblem(f!, u₀, (0.0, 10.0), p)

--- a/test/extinction_test.jl
+++ b/test/extinction_test.jl
@@ -4,11 +4,11 @@ using StableRNGs
 rng = StableRNG(12345)
 
 reactstoch = [
-    [1 => 1]
+    [1 => 1],
 ]
 
 netstoch = [
-    [1 => -1]
+    [1 => -1],
 ]
 
 Nsims = 10
@@ -16,13 +16,15 @@ rates = [1.0]
 dg = [[1]]
 majump = MassActionJump(rates, reactstoch, netstoch)
 u0 = [100000]
-dprob = DiscreteProblem(u0, (0.0, 1e5), rates)
+dprob = DiscreteProblem(u0, (0.0, 1.0e5), rates)
 algs = (JumpProcesses.JUMP_AGGREGATORS..., JumpProcesses.NullAggregator())
 
 for n in 1:Nsims
     for ssa in algs
-        local jprob = JumpProblem(dprob, ssa, majump, save_positions = (false, false),
-            rng = rng)
+        local jprob = JumpProblem(
+            dprob, ssa, majump, save_positions = (false, false),
+            rng = rng
+        )
         local sol = solve(jprob, SSAStepper())
         @test sol[1, end] == 0
         @test sol.t[end] < Inf
@@ -33,8 +35,10 @@ u0 = SA[10]
 dprob = DiscreteProblem(u0, (0.0, 100.0), rates)
 
 for ssa in algs
-    local jprob = JumpProblem(dprob, ssa, majump, save_positions = (false, false),
-        rng = rng)
+    local jprob = JumpProblem(
+        dprob, ssa, majump, save_positions = (false, false),
+        rng = rng
+    )
     local sol = solve(jprob, SSAStepper(), saveat = 100.0)
     @test sol[1, end] == 0
     @test sol.t[end] < Inf
@@ -45,14 +49,14 @@ Base.@kwdef mutable struct ExtinctionTest
     cnt::Int = 0
 end
 function (e::ExtinctionTest)(u, t, integrator)
-    (e.cnt == 0) && (integrator.cb.affect!.next_jump_time == Inf)
+    return (e.cnt == 0) && (integrator.cb.affect!.next_jump_time == Inf)
 end
 function (e::ExtinctionTest)(integrator)
     (saved, savedexactly) = savevalues!(integrator, true)
     @test saved == true
     @test savedexactly == true
     e.cnt += 1
-    nothing
+    return nothing
 end
 et = ExtinctionTest()
 cb = DiscreteCallback(et, et, save_positions = (false, false))
@@ -63,15 +67,17 @@ sol = solve(jprob, SSAStepper(), callback = cb, save_end = false)
 
 # test terminate
 function extinction_condition2(u, t, integrator)
-    u[1] == 1
+    return u[1] == 1
 end
 function extinction_affect!2(integrator)
     (saved, savedexactly) = savevalues!(integrator, true)
     terminate!(integrator)
-    nothing
+    return nothing
 end
-cb = DiscreteCallback(extinction_condition2, extinction_affect!2,
-    save_positions = (false, false))
+cb = DiscreteCallback(
+    extinction_condition2, extinction_affect!2,
+    save_positions = (false, false)
+)
 dprob = DiscreteProblem(u0, (0.0, 1000.0), rates)
 jprob = JumpProblem(dprob, majump; save_positions = (false, false), rng)
 sol = solve(jprob; callback = cb, save_end = false)

--- a/test/fp_unknowns.jl
+++ b/test/fp_unknowns.jl
@@ -9,16 +9,22 @@ rng = StableRNG(12345)
 #    1, X --> ∅
 function test(rng)
     # dep graphs
-    dg = [[1, 2, 3, 4],
+    dg = [
+        [1, 2, 3, 4],
         [2, 3, 4],
         [2, 3, 4],
-        [2, 3, 4]]
-    vtoj = [[2, 3, 4],
-        [2]]
-    jtov = [[1],
+        [2, 3, 4],
+    ]
+    vtoj = [
+        [2, 3, 4],
+        [2],
+    ]
+    jtov = [
+        [1],
         [1, 2],
         [1, 2],
-        [1]]
+        [1],
+    ]
 
     # reaction as MassActionJump
     sr = [1.0, 0.5, 4.0, 1.0]
@@ -34,9 +40,11 @@ function test(rng)
     Xmeans = zeros(length(SSAalgs))
     Ymeans = zeros(length(SSAalgs))
     for (j, agg) in enumerate(SSAalgs)
-        jprob = JumpProblem(dprob, agg, maj; save_positions = (false, false), rng,
+        jprob = JumpProblem(
+            dprob, agg, maj; save_positions = (false, false), rng,
             vartojumps_map = vtoj, jumptovars_map = jtov, dep_graph = dg,
-            scale_rates = false)
+            scale_rates = false
+        )
         for i in 1:Nsims
             sol = solve(jprob, SSAStepper())
             Xmeans[j] += sol[1, end]
@@ -44,7 +52,7 @@ function test(rng)
         end
     end
     Xmeans ./= Nsims
-    Ymeans ./= Nsims
+    return Ymeans ./= Nsims
     # for i in 2:length(SSAalgs)
     #     @test abs(Xmeans[i] - Xmeans[1]) < (.1 * Xmeans[1])
     #     @test abs(Ymeans[i] - Ymeans[1]) < (.1 * Ymeans[1])

--- a/test/functionwrappers.jl
+++ b/test/functionwrappers.jl
@@ -6,10 +6,12 @@ let
     rate(u, p, t; debug = true) = 5.0
     function affect!(integrator)
         integrator.u[1] += 1
-        nothing
+        return nothing
     end
-    jump = VariableRateJump(rate, affect!; urate = (u, p, t) -> 10.0,
-        rateinterval = (u, p, t) -> 0.1)
+    jump = VariableRateJump(
+        rate, affect!; urate = (u, p, t) -> 10.0,
+        rateinterval = (u, p, t) -> 0.1
+    )
 
     prob = DiscreteProblem([0.0], (0.0, 2.0), [1.0])
     jprob = JumpProblem(prob, Coevolve(), jump; dep_graph = [[1]], rng)

--- a/test/geneexpr_test.jl
+++ b/test/geneexpr_test.jl
@@ -18,7 +18,7 @@ SSAalgs = (JumpProcesses.JUMP_AGGREGATORS..., JumpProcesses.NullAggregator())
 Nsims = 8000
 tf = 1000.0
 u0 = [1, 0, 0, 0]
-expected_avg = 5.926553750000000e+02
+expected_avg = 5.92655375e+2
 reltol = 0.01
 
 # average number of proteins in a simulation
@@ -28,7 +28,7 @@ function runSSAs(jump_prob; use_stepper = true)
         sol = use_stepper ? solve(jump_prob, SSAStepper()) : solve(jump_prob)
         Psamp[i] = sol[3, end]
     end
-    mean(Psamp)
+    return mean(Psamp)
 end
 
 function runSSAs_ode(vrjprob)
@@ -61,7 +61,7 @@ reactstoch = [
     [2 => 1],
     [3 => 1],
     [1 => 1, 3 => 1],
-    [4 => 1]
+    [4 => 1],
 ]
 netstoch = [
     [2 => 1],
@@ -69,7 +69,7 @@ netstoch = [
     [2 => -1],
     [3 => -1],
     [1 => -1, 3 => -1, 4 => 1],
-    [1 => 1, 3 => 1, 4 => -1]
+    [1 => 1, 3 => 1, 4 => -1],
 ]
 spec_to_dep_jumps = [[1, 5], [2, 3], [4, 5], [6]]
 jump_to_dep_specs = [[2], [3], [2], [3], [1, 3, 4], [1, 3, 4]]
@@ -87,9 +87,11 @@ probf = DiscreteProblem(u0f, (0.0, tf), rates)
 if doplot
     plothand = plot(reuse = false)
     for alg in SSAalgs
-        local jump_prob = JumpProblem(prob, alg, majumps,
+        local jump_prob = JumpProblem(
+            prob, alg, majumps,
             vartojumps_map = spec_to_dep_jumps,
-            jumptovars_map = jump_to_dep_specs, rng = rng)
+            jumptovars_map = jump_to_dep_specs, rng = rng
+        )
         local sol = solve(jump_prob, SSAStepper())
         plot!(plothand, sol.t, sol[3, :], seriestype = :steppost)
     end
@@ -99,33 +101,43 @@ end
 # test the means
 if dotestmean
     for (i, alg) in enumerate(SSAalgs)
-        local jump_prob = JumpProblem(prob, alg, majumps, save_positions = (false, false),
+        local jump_prob = JumpProblem(
+            prob, alg, majumps, save_positions = (false, false),
             vartojumps_map = spec_to_dep_jumps,
-            jumptovars_map = jump_to_dep_specs, rng = rng)
+            jumptovars_map = jump_to_dep_specs, rng = rng
+        )
         means = runSSAs(jump_prob)
         relerr = abs(means - expected_avg) / expected_avg
-        doprintmeans && println("Mean from method: ", typeof(alg), " is = ", means,
-            ", rel err = ", relerr)
+        doprintmeans && println(
+            "Mean from method: ", typeof(alg), " is = ", means,
+            ", rel err = ", relerr
+        )
         @test abs(means - expected_avg) < reltol * expected_avg
 
         means = runSSAs(jump_prob; use_stepper = false)
         relerr = abs(means - expected_avg) / expected_avg
         @test abs(means - expected_avg) < reltol * expected_avg
 
-        jump_probf = JumpProblem(probf, alg, majumps, save_positions = (false, false),
+        jump_probf = JumpProblem(
+            probf, alg, majumps, save_positions = (false, false),
             vartojumps_map = spec_to_dep_jumps,
-            jumptovars_map = jump_to_dep_specs, rng = rng)
+            jumptovars_map = jump_to_dep_specs, rng = rng
+        )
         means = runSSAs(jump_probf)
         relerr = abs(means - expected_avg) / expected_avg
-        doprintmeans && println("Mean from method: ", typeof(alg), " is = ", means,
-            ", rel err = ", relerr)
+        doprintmeans && println(
+            "Mean from method: ", typeof(alg), " is = ", means,
+            ", rel err = ", relerr
+        )
         @test abs(means - expected_avg) < reltol * expected_avg
     end
 end
 
 # no-aggregator tests
-jump_prob = JumpProblem(prob, majumps; save_positions = (false, false),
-    vartojumps_map = spec_to_dep_jumps, jumptovars_map = jump_to_dep_specs, rng)
+jump_prob = JumpProblem(
+    prob, majumps; save_positions = (false, false),
+    vartojumps_map = spec_to_dep_jumps, jumptovars_map = jump_to_dep_specs, rng
+)
 @test abs(runSSAs(jump_prob) - expected_avg) < reltol * expected_avg
 @test abs(runSSAs(jump_prob; use_stepper = false) - expected_avg) < reltol * expected_avg
 
@@ -156,23 +168,27 @@ let
         integ.u[1] -= 1
         integ.u[3] -= 1
         integ.u[4] += 1
-        nothing
+        return nothing
     end
     function a6!(integ)
         integ.u[1] += 1
         integ.u[3] += 1
         integ.u[4] -= 1
-        nothing
+        return nothing
     end
-    crjs = JumpSet(ConstantRateJump(r1, a1!), ConstantRateJump(r2, a2!),
+    crjs = JumpSet(
+        ConstantRateJump(r1, a1!), ConstantRateJump(r2, a2!),
         ConstantRateJump(r3, a3!), ConstantRateJump(r4, a4!), ConstantRateJump(r5, a5!),
-        ConstantRateJump(r6, a6!))
-    vrjs = JumpSet(VariableRateJump(r1, a1!; save_positions = (false, false)),
+        ConstantRateJump(r6, a6!)
+    )
+    vrjs = JumpSet(
+        VariableRateJump(r1, a1!; save_positions = (false, false)),
         VariableRateJump(r2, a2!, save_positions = (false, false)),
         VariableRateJump(r3, a3!, save_positions = (false, false)),
         VariableRateJump(r4, a4!, save_positions = (false, false)),
         VariableRateJump(r5, a5!, save_positions = (false, false)),
-        VariableRateJump(r6, a6!, save_positions = (false, false)))
+        VariableRateJump(r6, a6!, save_positions = (false, false))
+    )
 
     prob = DiscreteProblem(u0, (0.0, tf), rates)
     crjprob = JumpProblem(prob, crjs; save_positions = (false, false), rng)
@@ -187,7 +203,8 @@ let
 
     for vr_agg in (VR_FRM(), VR_Direct(), VR_DirectFW())
         vrjprob = JumpProblem(
-            oprob, vrjs; vr_aggregator = vr_agg, save_positions = (false, false), rng)
+            oprob, vrjs; vr_aggregator = vr_agg, save_positions = (false, false), rng
+        )
         vrjmean = runSSAs_ode(vrjprob)
         @test abs(vrjmean - crjmean) < reltol * crjmean
     end

--- a/test/gpu/regular_jumps.jl
+++ b/test/gpu/regular_jumps.jl
@@ -33,12 +33,16 @@ let
     rj = RegularJump(regular_rate, regular_c, 3)
     jump_prob = JumpProblem(prob_disc, PureLeaping(), rj)
 
-    sol = solve(EnsembleProblem(jump_prob), SimpleTauLeaping(),
-        EnsembleGPUKernel(CUDABackend()); trajectories = Nsims, dt = 1.0)
+    sol = solve(
+        EnsembleProblem(jump_prob), SimpleTauLeaping(),
+        EnsembleGPUKernel(CUDABackend()); trajectories = Nsims, dt = 1.0
+    )
     mean_kernel = mean(sol.u[i][1, end] for i in 1:Nsims)
 
-    sol = solve(EnsembleProblem(jump_prob), SimpleTauLeaping(),
-        EnsembleSerial(); trajectories = Nsims, dt = 1.0)
+    sol = solve(
+        EnsembleProblem(jump_prob), SimpleTauLeaping(),
+        EnsembleSerial(); trajectories = Nsims, dt = 1.0
+    )
     mean_serial = mean(sol.u[i][1, end] for i in 1:Nsims)
 
     @test isapprox(mean_kernel, mean_serial, rtol = 0.05)
@@ -74,12 +78,16 @@ let
     rj = RegularJump(regular_rate, regular_c, 3)
     jump_prob = JumpProblem(prob_disc, PureLeaping(), rj; rng = StableRNG(12345))
 
-    sol = solve(EnsembleProblem(jump_prob), SimpleTauLeaping(),
-        EnsembleGPUKernel(CUDABackend()); trajectories = Nsims, dt = 1.0)
+    sol = solve(
+        EnsembleProblem(jump_prob), SimpleTauLeaping(),
+        EnsembleGPUKernel(CUDABackend()); trajectories = Nsims, dt = 1.0
+    )
     mean_kernel = mean(sol.u[i][end, end] for i in 1:Nsims)
 
-    sol = solve(EnsembleProblem(jump_prob), SimpleTauLeaping(),
-        EnsembleSerial(); trajectories = Nsims, dt = 1.0)
+    sol = solve(
+        EnsembleProblem(jump_prob), SimpleTauLeaping(),
+        EnsembleSerial(); trajectories = Nsims, dt = 1.0
+    )
     mean_serial = mean(sol.u[i][end, end] for i in 1:Nsims)
 
     @test isapprox(mean_kernel, mean_serial, rtol = 0.05)

--- a/test/jprob_symbol_indexing.jl
+++ b/test/jprob_symbol_indexing.jl
@@ -7,8 +7,10 @@ affect2!(integ) = (integ.u[2] += 1)
 crj1 = ConstantRateJump(rate1, affect1!)
 crj2 = ConstantRateJump(rate2, affect2!)
 maj = MassActionJump([[1 => 1], [1 => 1]], [[1 => -1], [1 => -1]]; param_idxs = [1, 2])
-g = DiscreteFunction((du, u, p, t) -> nothing;
-    sys = SymbolicIndexingInterface.SymbolCache([:a, :b], [:p1, :p2], :t))
+g = DiscreteFunction(
+    (du, u, p, t) -> nothing;
+    sys = SymbolicIndexingInterface.SymbolCache([:a, :b], [:p1, :p2], :t)
+)
 dprob = DiscreteProblem(g, [0, 10], (0.0, 10.0), [1.0, 2.0])
 jprob = JumpProblem(dprob, Direct(), crj1, crj2, maj)
 

--- a/test/linearreaction_test.jl
+++ b/test/linearreaction_test.jl
@@ -32,7 +32,7 @@ function runSSAs(jump_prob)
         sol = solve(jump_prob, SSAStepper())
         Asamp[i] = sol[1, end]
     end
-    mean(Asamp)
+    return mean(Asamp)
 end
 
 # uses constant jumps as a tuple within a JumpSet
@@ -43,7 +43,7 @@ function A_to_B_tuple(N, method)
         ratefunc = (u, p, t) -> rates[i] * u[1]
         affect! = function (integrator)
             integrator.u[1] -= 1
-            integrator.u[2] += 1
+            return integrator.u[2] += 1
         end
         push!(jumpvec, ConstantRateJump(ratefunc, affect!))
     end
@@ -52,10 +52,12 @@ function A_to_B_tuple(N, method)
     jumps = ((jump for jump in jumpvec)...,)
     jset = JumpSet((), jumps, nothing, nothing)
     prob = DiscreteProblem([A0, 0], (0.0, tf))
-    jump_prob = JumpProblem(prob, method, jset; save_positions = (false, false), rng,
-        namedpars...)
+    jump_prob = JumpProblem(
+        prob, method, jset; save_positions = (false, false), rng,
+        namedpars...
+    )
 
-    jump_prob
+    return jump_prob
 end
 
 # uses constant jumps as a vector within a JumpSet
@@ -66,7 +68,7 @@ function A_to_B_vec(N, method)
         ratefunc = (u, p, t) -> rates[i] * u[1]
         affect! = function (integrator)
             integrator.u[1] -= 1
-            integrator.u[2] += 1
+            return integrator.u[2] += 1
         end
         push!(jumps, ConstantRateJump(ratefunc, affect!))
     end
@@ -74,10 +76,12 @@ function A_to_B_vec(N, method)
     # convert jumpvec to tuple to send to JumpProblem...
     jset = JumpSet((), jumps, nothing, nothing)
     prob = DiscreteProblem([A0, 0], (0.0, tf))
-    jump_prob = JumpProblem(prob, method, jset; save_positions = (false, false), rng,
-        namedpars...)
+    jump_prob = JumpProblem(
+        prob, method, jset; save_positions = (false, false), rng,
+        namedpars...
+    )
 
-    jump_prob
+    return jump_prob
 end
 
 # uses a single mass action jump to represent all reactions
@@ -92,10 +96,12 @@ function A_to_B_ma(N, method)
     majumps = MassActionJump(rates, reactstoch, netstoch)
     jset = JumpSet((), (), nothing, majumps)
     prob = DiscreteProblem([A0, 0], (0.0, tf))
-    jump_prob = JumpProblem(prob, method, jset; save_positions = (false, false), rng,
-        namedpars...)
+    jump_prob = JumpProblem(
+        prob, method, jset; save_positions = (false, false), rng,
+        namedpars...
+    )
 
-    jump_prob
+    return jump_prob
 end
 
 # uses one mass action jump to represent half the reactions and a vector
@@ -118,7 +124,7 @@ function A_to_B_hybrid(N, method)
         ratefunc = (u, p, t) -> rates[i] * u[1]
         affect! = function (integrator)
             integrator.u[1] -= 1
-            integrator.u[2] += 1
+            return integrator.u[2] += 1
         end
         push!(jumps, ConstantRateJump(ratefunc, affect!))
     end
@@ -126,10 +132,12 @@ function A_to_B_hybrid(N, method)
     majumps = MassActionJump(rates[1:switchidx], reactstoch, netstoch)
     jset = JumpSet((), jumps, nothing, majumps)
     prob = DiscreteProblem([A0, 0], (0.0, tf))
-    jump_prob = JumpProblem(prob, method, jset; save_positions = (false, false), rng,
-        namedpars...)
+    jump_prob = JumpProblem(
+        prob, method, jset; save_positions = (false, false), rng,
+        namedpars...
+    )
 
-    jump_prob
+    return jump_prob
 end
 
 # uses a mass action jump to represent half the reactions and a vector
@@ -152,7 +160,7 @@ function A_to_B_hybrid_nojset(N, method)
         ratefunc = (u, p, t) -> rates[i] * u[1]
         affect! = function (integrator)
             integrator.u[1] -= 1
-            integrator.u[2] += 1
+            return integrator.u[2] += 1
         end
         push!(jumpvec, ConstantRateJump(ratefunc, affect!))
     end
@@ -160,10 +168,12 @@ function A_to_B_hybrid_nojset(N, method)
     majumps = MassActionJump(rates[1:switchidx], reactstoch, netstoch)
     jumps = (constjumps..., majumps)
     prob = DiscreteProblem([A0, 0], (0.0, tf))
-    jump_prob = JumpProblem(prob, method, jumps...; save_positions = (false, false),
-        rng, namedpars...)
+    jump_prob = JumpProblem(
+        prob, method, jumps...; save_positions = (false, false),
+        rng, namedpars...
+    )
 
-    jump_prob
+    return jump_prob
 end
 
 # uses a vector of mass action jumps of vectors to represent half the reactions and a vector
@@ -184,16 +194,18 @@ function A_to_B_hybrid_vecs(N, method)
         ratefunc = (u, p, t) -> rates[i] * u[1]
         affect! = function (integrator)
             integrator.u[1] -= 1
-            integrator.u[2] += 1
+            return integrator.u[2] += 1
         end
         push!(jumpvec, ConstantRateJump(ratefunc, affect!))
     end
     jset = JumpSet((), jumpvec, nothing, majumps)
     prob = DiscreteProblem([A0, 0], (0.0, tf))
-    jump_prob = JumpProblem(prob, method, jset; save_positions = (false, false), rng,
-        namedpars...)
+    jump_prob = JumpProblem(
+        prob, method, jset; save_positions = (false, false), rng,
+        namedpars...
+    )
 
-    jump_prob
+    return jump_prob
 end
 
 # uses a vector of scalar mass action jumps to represent half the reactions and a vector
@@ -214,16 +226,18 @@ function A_to_B_hybrid_vecs_scalars(N, method)
         ratefunc = (u, p, t) -> rates[i] * u[1]
         affect! = function (integrator)
             integrator.u[1] -= 1
-            integrator.u[2] += 1
+            return integrator.u[2] += 1
         end
         push!(jumpvec, ConstantRateJump(ratefunc, affect!))
     end
     jset = JumpSet((), jumpvec, nothing, majumps)
     prob = DiscreteProblem([A0, 0], (0.0, tf))
-    jump_prob = JumpProblem(prob, method, jset; save_positions = (false, false), rng,
-        namedpars...)
+    jump_prob = JumpProblem(
+        prob, method, jset; save_positions = (false, false), rng,
+        namedpars...
+    )
 
-    jump_prob
+    return jump_prob
 end
 
 # uses a vector of scalar mass action jumps to represent half the reactions and a vector
@@ -244,17 +258,19 @@ function A_to_B_hybrid_tups_scalars(N, method)
         ratefunc = (u, p, t) -> rates[i] * u[1]
         affect! = function (integrator)
             integrator.u[1] -= 1
-            integrator.u[2] += 1
+            return integrator.u[2] += 1
         end
         push!(jumpvec, ConstantRateJump(ratefunc, affect!))
     end
 
     jumps = ((maj for maj in majumpsv)..., (jump for jump in jumpvec)...)
     prob = DiscreteProblem([A0, 0], (0.0, tf))
-    jump_prob = JumpProblem(prob, method, jumps...; save_positions = (false, false),
-        rng, namedpars...)
+    jump_prob = JumpProblem(
+        prob, method, jumps...; save_positions = (false, false),
+        rng, namedpars...
+    )
 
-    jump_prob
+    return jump_prob
 end
 
 # uses a mass action jump to represent half the reactions and a tuple
@@ -275,22 +291,26 @@ function A_to_B_hybrid_tups(N, method)
         ratefunc = (u, p, t) -> rates[i] * u[1]
         affect! = function (integrator)
             integrator.u[1] -= 1
-            integrator.u[2] += 1
+            return integrator.u[2] += 1
         end
         push!(jumpvec, ConstantRateJump(ratefunc, affect!))
     end
     jumps = ((jump for jump in jumpvec)...,)
     jset = JumpSet((), jumps, nothing, majumps)
     prob = DiscreteProblem([A0, 0], (0.0, tf))
-    jump_prob = JumpProblem(prob, method, jset; save_positions = (false, false), rng,
-        namedpars...)
+    jump_prob = JumpProblem(
+        prob, method, jset; save_positions = (false, false), rng,
+        namedpars...
+    )
 
-    jump_prob
+    return jump_prob
 end
 
-jump_prob_gens = [A_to_B_tuple, A_to_B_vec, A_to_B_ma, A_to_B_hybrid, A_to_B_hybrid_nojset,
+jump_prob_gens = [
+    A_to_B_tuple, A_to_B_vec, A_to_B_ma, A_to_B_hybrid, A_to_B_hybrid_nojset,
     A_to_B_hybrid_vecs, A_to_B_hybrid_vecs_scalars, A_to_B_hybrid_tups,
-    A_to_B_hybrid_tups_scalars]
+    A_to_B_hybrid_tups_scalars,
+]
 #jump_prob_gens = [A_to_B_tuple, A_to_B_ma, A_to_B_hybrid, A_to_B_hybrid_vecs, A_to_B_hybrid_vecs_scalars,A_to_B_hybrid_tups_scalars]
 
 for method in SSAalgs
@@ -302,8 +322,10 @@ for method in SSAalgs
         local jump_prob = jump_prob_gen(Nrxs, method)
         meanval = runSSAs(jump_prob)
         if doprint
-            println("Method: ", method, ", Jump input types: ", jump_prob_gen,
-                ", sample mean = ", meanval, ", actual mean = ", exactmeanval)
+            println(
+                "Method: ", method, ", Jump input types: ", jump_prob_gen,
+                ", sample mean = ", meanval, ", actual mean = ", exactmeanval
+            )
         end
         @test abs(meanval - exactmeanval) < 1.0
     end
@@ -319,8 +341,10 @@ for method in SSAalgs
         local jump_prob = jump_prob_gen(Nrxs, method)
         meanval = runSSAs(jump_prob)
         if doprint
-            println("Method: ", method, ", Jump input types: ", jump_prob_gen,
-                ", sample mean = ", meanval, ", actual mean = ", exactmeanval)
+            println(
+                "Method: ", method, ", Jump input types: ", jump_prob_gen,
+                ", sample mean = ", meanval, ", actual mean = ", exactmeanval
+            )
         end
         @test abs(meanval - exactmeanval) < 1.0
     end

--- a/test/longtimes_test.jl
+++ b/test/longtimes_test.jl
@@ -8,7 +8,7 @@ ns = [[1 => 1], [1 => -1], [1 => 1]]
 rs = [[1 => 1], [1 => 1], Pair{Int64, Int64}[]]
 maj = MassActionJump(p, rs, ns)
 u0 = [5]
-tspan = (0.0, 2e6)
+tspan = (0.0, 2.0e6)
 dt = tspan[2] / 1000
 dprob = DiscreteProblem(u0, tspan, p)
 jprob = JumpProblem(dprob, Direct(), maj, save_positions = (false, false), rng = rng)

--- a/test/monte_carlo_test.jl
+++ b/test/monte_carlo_test.jl
@@ -10,25 +10,33 @@ affect! = integrator -> (integrator.u[1] = integrator.u[1] / 2)
 jump = VariableRateJump(rate, affect!, save_positions = (false, true))
 jump_prob = JumpProblem(prob, Direct(), jump; vr_aggregator = VR_FRM(), rng)
 monte_prob = EnsembleProblem(jump_prob)
-sol = solve(monte_prob, SRIW1(), EnsembleSerial(), trajectories = 3,
-    save_everystep = false, dt = 0.001, adaptive = false)
+sol = solve(
+    monte_prob, SRIW1(), EnsembleSerial(), trajectories = 3,
+    save_everystep = false, dt = 0.001, adaptive = false
+)
 @test sol.u[1].t[2] != sol.u[2].t[2] != sol.u[3].t[2]
 
 jump_prob = JumpProblem(prob, Direct(), jump; vr_aggregator = VR_Direct(), rng)
 monte_prob = EnsembleProblem(jump_prob)
-sol = solve(monte_prob, SRIW1(), EnsembleSerial(), trajectories = 3,
-    save_everystep = false, dt = 0.001, adaptive = false)
+sol = solve(
+    monte_prob, SRIW1(), EnsembleSerial(), trajectories = 3,
+    save_everystep = false, dt = 0.001, adaptive = false
+)
 @test allunique(sol.u[1].t)
 
 jump_prob = JumpProblem(prob, Direct(), jump; vr_aggregator = VR_DirectFW(), rng)
 monte_prob = EnsembleProblem(jump_prob)
-sol = solve(monte_prob, SRIW1(), EnsembleSerial(), trajectories = 3,
-    save_everystep = false, dt = 0.001, adaptive = false)
+sol = solve(
+    monte_prob, SRIW1(), EnsembleSerial(), trajectories = 3,
+    save_everystep = false, dt = 0.001, adaptive = false
+)
 @test allunique(sol.u[1].t)
 
 jump = ConstantRateJump(rate, affect!)
 jump_prob = JumpProblem(prob, Direct(), jump; save_positions = (true, false), rng)
 monte_prob = EnsembleProblem(jump_prob)
-sol = solve(monte_prob, SRIW1(), EnsembleSerial(), trajectories = 3,
-    save_everystep = false, dt = 0.001, adaptive = false)
+sol = solve(
+    monte_prob, SRIW1(), EnsembleSerial(), trajectories = 3,
+    save_everystep = false, dt = 0.001, adaptive = false
+)
 @test sol.u[1].t[2] != sol.u[2].t[2] != sol.u[3].t[2]

--- a/test/qa.jl
+++ b/test/qa.jl
@@ -5,24 +5,26 @@ using Test
 
 @testset "QA Tests" begin
     @testset "Aqua tests" begin
-        Aqua.test_all(JumpProcesses;
-                      ambiguities = false,  # TODO: fix ambiguities and enable
-                      deps_compat = true,
-                      piracies = false,  # We define default solvers for AbstractJumpProblem
-                      unbound_args = true,
-                      undefined_exports = true,
-                      project_extras = true,
-                      stale_deps = true,
-                      persistent_tasks = false)  # disabled due to false positives
+        Aqua.test_all(
+            JumpProcesses;
+            ambiguities = false,  # TODO: fix ambiguities and enable
+            deps_compat = true,
+            piracies = false,  # We define default solvers for AbstractJumpProblem
+            unbound_args = true,
+            undefined_exports = true,
+            project_extras = true,
+            stale_deps = true,
+            persistent_tasks = false
+        )  # disabled due to false positives
     end
 
     @testset "ExplicitImports tests" begin
         # Check that we're using explicit imports
         @test check_no_implicit_imports(JumpProcesses) === nothing
-        
+
         # Check for stale explicit imports (imports that are not used)
         @test check_no_stale_explicit_imports(JumpProcesses) === nothing
-        
+
         # Allow some flexibility for non-public imports during transition
         # This can be made stricter once all non-public API usage is resolved
         @test_nowarn check_all_explicit_imports_via_owners(JumpProcesses)

--- a/test/regular_jumps.jl
+++ b/test/regular_jumps.jl
@@ -5,7 +5,7 @@ rng = StableRNG(12345)
 
 function regular_rate(out, u, p, t)
     out[1] = (0.1 / 1000.0) * u[1] * u[2]
-    out[2] = 0.01u[2]
+    return out[2] = 0.01u[2]
 end
 
 const dc = zeros(3, 2)
@@ -15,7 +15,7 @@ dc[2, 2] = -1
 dc[3, 2] = 1
 
 function regular_c(du, u, p, t, counts, mark)
-    mul!(du, dc, counts)
+    return mul!(du, dc, counts)
 end
 
 rj = RegularJump(regular_rate, regular_c, 2)
@@ -31,63 +31,65 @@ sol = solve(jump_prob, SimpleTauLeaping(); dt = 1.0)
     tspan = (0.0, 10.0)
     p = [0.1, 0.2]
     prob = DiscreteProblem(u0, tspan, p)
-    
+
     # Create MassActionJump
     reactant_stoich = [[1 => 1], [1 => 2]]
     net_stoich = [[1 => -1, 2 => 1], [1 => -2, 3 => 1]]
     rates = [0.1, 0.05]
     maj = MassActionJump(rates, reactant_stoich, net_stoich)
-    
+
     # Test PureLeaping JumpProblem creation
     jp_pure = JumpProblem(prob, PureLeaping(), JumpSet(maj); rng)
     @test jp_pure.aggregator isa PureLeaping
     @test jp_pure.discrete_jump_aggregation === nothing
     @test jp_pure.massaction_jump !== nothing
     @test length(jp_pure.jump_callback.discrete_callbacks) == 0
-    
+
     # Test with ConstantRateJump
     rate(u, p, t) = p[1] * u[1]
     affect!(integrator) = (integrator.u[1] -= 1; integrator.u[3] += 1)
     crj = ConstantRateJump(rate, affect!)
-    
+
     jp_pure_crj = JumpProblem(prob, PureLeaping(), JumpSet(crj); rng)
     @test jp_pure_crj.aggregator isa PureLeaping
     @test jp_pure_crj.discrete_jump_aggregation === nothing
     @test length(jp_pure_crj.constant_jumps) == 1
-    
+
     # Test with VariableRateJump
     vrate(u, p, t) = t * p[1] * u[1]
     vaffect!(integrator) = (integrator.u[1] -= 1; integrator.u[3] += 1)
     vrj = VariableRateJump(vrate, vaffect!)
-    
+
     jp_pure_vrj = JumpProblem(prob, PureLeaping(), JumpSet(vrj); rng)
     @test jp_pure_vrj.aggregator isa PureLeaping
     @test jp_pure_vrj.discrete_jump_aggregation === nothing
     @test length(jp_pure_vrj.variable_jumps) == 1
-    
+
     # Test with RegularJump
     function rj_rate(out, u, p, t)
         out[1] = p[1] * u[1]
     end
-    
+
     rj_dc = zeros(3, 1)
     rj_dc[1, 1] = -1
     rj_dc[3, 1] = 1
-    
+
     function rj_c(du, u, p, t, counts, mark)
         mul!(du, rj_dc, counts)
     end
-    
+
     regj = RegularJump(rj_rate, rj_c, 1)
-    
+
     jp_pure_regj = JumpProblem(prob, PureLeaping(), JumpSet(regj); rng)
     @test jp_pure_regj.aggregator isa PureLeaping
     @test jp_pure_regj.discrete_jump_aggregation === nothing
     @test jp_pure_regj.regular_jump !== nothing
-    
+
     # Test mixed jump types
-    mixed_jumps = JumpSet(; massaction_jumps = maj, constant_jumps = (crj,), 
-        variable_jumps = (vrj,), regular_jumps = regj)
+    mixed_jumps = JumpSet(;
+        massaction_jumps = maj, constant_jumps = (crj,),
+        variable_jumps = (vrj,), regular_jumps = regj
+    )
     jp_pure_mixed = JumpProblem(prob, PureLeaping(), mixed_jumps; rng)
     @test jp_pure_mixed.aggregator isa PureLeaping
     @test jp_pure_mixed.discrete_jump_aggregation === nothing
@@ -95,18 +97,22 @@ sol = solve(jump_prob, SimpleTauLeaping(); dt = 1.0)
     @test length(jp_pure_mixed.constant_jumps) == 1
     @test length(jp_pure_mixed.variable_jumps) == 1
     @test jp_pure_mixed.regular_jump !== nothing
-    
+
     # Test spatial system error
     spatial_sys = CartesianGrid((2, 2))
     hopping_consts = [1.0]
-    @test_throws ErrorException JumpProblem(prob, PureLeaping(), JumpSet(maj); rng,
-                                          spatial_system = spatial_sys)
-    @test_throws ErrorException JumpProblem(prob, PureLeaping(), JumpSet(maj); rng,
-                                          hopping_constants = hopping_consts)
-    
+    @test_throws ErrorException JumpProblem(
+        prob, PureLeaping(), JumpSet(maj); rng,
+        spatial_system = spatial_sys
+    )
+    @test_throws ErrorException JumpProblem(
+        prob, PureLeaping(), JumpSet(maj); rng,
+        hopping_constants = hopping_consts
+    )
+
     # Test MassActionJump with parameter mapping
     maj_params = MassActionJump(reactant_stoich, net_stoich; param_idxs = [1, 2])
     jp_params = JumpProblem(prob, PureLeaping(), JumpSet(maj_params); rng)
-    scaled_rates = [p[1], p[2]/2]
+    scaled_rates = [p[1], p[2] / 2]
     @test jp_params.massaction_jump.scaled_rates == scaled_rates
 end

--- a/test/remake_test.jl
+++ b/test/remake_test.jl
@@ -5,14 +5,14 @@ rng = StableRNG(12345)
 rate = (u, p, t) -> p[1] * u[1] * u[2]
 affect! = function (integrator)
     integrator.u[1] -= 1
-    integrator.u[2] += 1
+    return integrator.u[2] += 1
 end
 jump = ConstantRateJump(rate, affect!)
 
 rate = (u, p, t) -> p[2] * u[2]
 affect! = function (integrator)
     integrator.u[2] -= 1
-    integrator.u[3] += 1
+    return integrator.u[3] += 1
 end
 jump2 = ConstantRateJump(rate, affect!)
 
@@ -21,8 +21,10 @@ p = (0.1 / 1000, 0.01)
 tspan = (0.0, 2500.0)
 
 dprob = DiscreteProblem(u0, tspan, p)
-jprob = JumpProblem(dprob, Direct(), jump, jump2, save_positions = (false, false),
-    rng = rng)
+jprob = JumpProblem(
+    dprob, Direct(), jump, jump2, save_positions = (false, false),
+    rng = rng
+)
 sol = solve(jprob, SSAStepper())
 @test sol[3, end] == 1000
 
@@ -65,8 +67,8 @@ sol3 = solve(jprob3, SSAStepper())
 #################
 
 # test error handling
-@test_throws ErrorException jprob4=remake(jprob, prob = dprob2, p = p2)
-@test_throws ErrorException jprob5=remake(jprob, aggregator = RSSA())
+@test_throws ErrorException jprob4 = remake(jprob, prob = dprob2, p = p2)
+@test_throws ErrorException jprob5 = remake(jprob, aggregator = RSSA())
 
 # test for #446
 let
@@ -97,7 +99,7 @@ let
     jprob3 = remake(jprob2; u0)
     sol = solve(jprob3, Tsit5())
     @test all(==(0.0), sol[1, :])
-    @test_throws ErrorException jprob4=remake(jprob, u0 = 1)
+    @test_throws ErrorException jprob4 = remake(jprob, u0 = 1)
 end
 
 # tests when changing u0 via a passed in prob
@@ -118,7 +120,7 @@ let
     @test all(==(0.0), sol[1, :])
     u0 = [4.0]
     prob2 = remake(jprob.prob; u0)
-    @test_throws ErrorException jprob2=remake(jprob; prob = prob2)
+    @test_throws ErrorException jprob2 = remake(jprob; prob = prob2)
     u0eja = JumpProcesses.remake_extended_u0(jprob.prob, u0, rng)
     prob3 = remake(jprob.prob; u0 = u0eja)
     jprob3 = remake(jprob; prob = prob3)

--- a/test/save_positions.jl
+++ b/test/save_positions.jl
@@ -12,21 +12,28 @@ let
         # set the rate to 0, so that no jump ever occurs; but urate is positive so
         # Coevolve will consider many candidates before the end of the simmulation.
         # None of these points should be saved.
-        jump = VariableRateJump((u, p, t) -> 0, (integrator) -> integrator.u[1] += 1;
-            urate = (u, p, t) -> 1.0, rateinterval = (u, p, t) -> 5.0)
-        jumpproblem = JumpProblem(dprob, alg, jump; dep_graph = [[1]],
-            save_positions = (false, true), rng)
+        jump = VariableRateJump(
+            (u, p, t) -> 0, (integrator) -> integrator.u[1] += 1;
+            urate = (u, p, t) -> 1.0, rateinterval = (u, p, t) -> 5.0
+        )
+        jumpproblem = JumpProblem(
+            dprob, alg, jump; dep_graph = [[1]],
+            save_positions = (false, true), rng
+        )
         sol = solve(jumpproblem, SSAStepper())
         @test sol.t == [0.0, 30.0]
 
         oprob = ODEProblem((du, u, p, t) -> 0, u0, tspan)
-        jump = VariableRateJump((u, p, t) -> 0, (integrator) -> integrator.u[1] += 1;
-            urate = (u, p, t) -> 1.0, rateinterval = (u, p, t) -> 5.0)
+        jump = VariableRateJump(
+            (u, p, t) -> 0, (integrator) -> integrator.u[1] += 1;
+            urate = (u, p, t) -> 1.0, rateinterval = (u, p, t) -> 5.0
+        )
 
         for vr_agg in (VR_FRM(), VR_Direct(), VR_DirectFW())
             jumpproblem = JumpProblem(
                 oprob, alg, jump; vr_aggregator = vr_agg, dep_graph = [[1]],
-                save_positions = (false, true), rng)
+                save_positions = (false, true), rng
+            )
             sol = solve(jumpproblem, Tsit5(); save_everystep = false)
             @test sol.t == [0.0, 30.0]
         end

--- a/test/saveat_regression.jl
+++ b/test/saveat_regression.jl
@@ -14,15 +14,17 @@ jprob = JumpProblem(dprob, Direct(), maj, save_positions = (false, false), rng =
 ts = collect(0:0.002:tspan[2])
 NA = zeros(length(ts))
 Nsims = 10_000
-sol = JumpProcesses.solve(EnsembleProblem(jprob), SSAStepper(), saveat = ts,
-    trajectories = Nsims)
+sol = JumpProcesses.solve(
+    EnsembleProblem(jprob), SSAStepper(), saveat = ts,
+    trajectories = Nsims
+)
 
 for i in 1:length(sol)
     NA .+= sol.u[i][1, :]
 end
 
 for i in 1:length(ts)
-    @test NA[i] / Nsims≈exp(-10 * ts[i]) rtol=1e-1
+    @test NA[i] / Nsims ≈ exp(-10 * ts[i]) rtol = 1.0e-1
 end
 
 NA = zeros(length(ts))
@@ -38,5 +40,5 @@ for i in 1:Nsims
 end
 
 for i in 1:length(ts)
-    @test NA[i] / Nsims≈exp(-10 * ts[i]) rtol=1e-1
+    @test NA[i] / Nsims ≈ exp(-10 * ts[i]) rtol = 1.0e-1
 end

--- a/test/sir_model.jl
+++ b/test/sir_model.jl
@@ -6,14 +6,14 @@ rng = StableRNG(12345)
 rate = (u, p, t) -> (0.1 / 1000.0) * u[1] * u[2]
 affect! = function (integrator)
     integrator.u[1] -= 1
-    integrator.u[2] += 1
+    return integrator.u[2] += 1
 end
 jump = ConstantRateJump(rate, affect!)
 
 rate = (u, p, t) -> 0.01u[2]
 affect! = function (integrator)
     integrator.u[2] -= 1
-    integrator.u[3] += 1
+    return integrator.u[3] += 1
 end
 jump2 = ConstantRateJump(rate, affect!)
 
@@ -24,7 +24,7 @@ integrator = init(jump_prob, FunctionMap())
 condition(u, t, integrator) = t == 100
 function purge_affect!(integrator)
     integrator.u[2] ÷= 10
-    reset_aggregated_jumps!(integrator)
+    return reset_aggregated_jumps!(integrator)
 end
 cb = DiscreteCallback(condition, purge_affect!, save_positions = (false, false))
 sol = solve(jump_prob, FunctionMap(), callback = cb, tstops = [100])
@@ -34,11 +34,15 @@ sol = solve(jump_prob, SSAStepper(), callback = cb, tstops = [100])
 let
     # here we order S = 1, I = 2, and R = 3
     # substrate stoichiometry:
-    substoich = [[1 => 1, 2 => 1],    # 1*S + 1*I
-        [2 => 1]]                     # 1*I
+    substoich = [
+        [1 => 1, 2 => 1],    # 1*S + 1*I
+        [2 => 1],
+    ]                     # 1*I
     # net change by each jump type
-    netstoich = [[1 => -1, 2 => 1],   # S -> S-1, I -> I+1
-        [2 => -1, 3 => 1]]            # I -> I-1, R -> R+1
+    netstoich = [
+        [1 => -1, 2 => 1],   # S -> S-1, I -> I+1
+        [2 => -1, 3 => 1],
+    ]            # I -> I-1, R -> R+1
     # rate constants for each jump
     p = (0.1 / 1000, 0.01)
 

--- a/test/spatial/ABC.jl
+++ b/test/spatial/ABC.jl
@@ -44,23 +44,35 @@ function get_mean_end_state(jump_prob, Nsims)
         sol = solve(jump_prob, SSAStepper())
         end_state .+= sol.u[end]
     end
-    end_state / Nsims
+    return end_state / Nsims
 end
 
 # testing
 grids = [CartesianGridRej(dims), Graphs.grid(dims)]
-jump_problems = JumpProblem[JumpProblem(prob, NSM(), majumps,
-                                hopping_constants = hopping_constants,
-                                spatial_system = grid,
-                                save_positions = (false, false), rng = rng)
-                            for grid in grids]
-push!(jump_problems,
-    JumpProblem(prob, DirectCRDirect(), majumps, hopping_constants = hopping_constants,
-        spatial_system = grids[1], save_positions = (false, false), rng = rng))
+jump_problems = JumpProblem[
+    JumpProblem(
+            prob, NSM(), majumps,
+            hopping_constants = hopping_constants,
+            spatial_system = grid,
+            save_positions = (false, false), rng = rng
+        )
+        for grid in grids
+]
+push!(
+    jump_problems,
+    JumpProblem(
+        prob, DirectCRDirect(), majumps, hopping_constants = hopping_constants,
+        spatial_system = grids[1], save_positions = (false, false), rng = rng
+    )
+)
 # setup flattenned jump prob
-push!(jump_problems,
-    JumpProblem(prob, NRM(), majumps, hopping_constants = hopping_constants,
-        spatial_system = grids[1], save_positions = (false, false), rng = rng))
+push!(
+    jump_problems,
+    JumpProblem(
+        prob, NRM(), majumps, hopping_constants = hopping_constants,
+        spatial_system = grids[1], save_positions = (false, false), rng = rng
+    )
+)
 # test
 for spatial_jump_prob in jump_problems
     solution = solve(spatial_jump_prob, SSAStepper())

--- a/test/spatial/bracketing.jl
+++ b/test/spatial/bracketing.jl
@@ -16,8 +16,10 @@ site_rates = JP.LowHigh(zeros(n), zeros(n))
 majump_rates = [0.1] # death at rate 0.1
 reactstoch = [[1 => 1]]
 netstoch = [[1 => -1]]
-majump = MassActionJump(majump_rates, reactstoch,
-    netstoch)
+majump = MassActionJump(
+    majump_rates, reactstoch,
+    netstoch
+)
 rx_rates = JP.LowHigh(JP.RxRates(n, majump))
 
 # set up hop rates
@@ -40,18 +42,18 @@ for site in 1:num_sites(spatial_system)
 end
 
 # test species brackets
-@test u_low_high.low[1, 1]≈u[1, 1] * (1 - fluctuation_rate) atol=1
-@test u_low_high.high[1, 1]≈u[1, 1] * (1 + fluctuation_rate) atol=1
+@test u_low_high.low[1, 1] ≈ u[1, 1] * (1 - fluctuation_rate) atol = 1
+@test u_low_high.high[1, 1] ≈ u[1, 1] * (1 + fluctuation_rate) atol = 1
 
 # test site rate brackets
 site = 1
 rx = 1
 species = 1
 @test JP.total_site_rx_rate(rx_rates.low, site) ==
-      majump_rates[rx] * u_low_high.low[species, site]
+    majump_rates[rx] * u_low_high.low[species, site]
 @test JP.total_site_rx_rate(rx_rates.high, site) ==
-      majump_rates[rx] * u_low_high.high[species, site]
+    majump_rates[rx] * u_low_high.high[species, site]
 @test JP.total_site_hop_rate(hop_rates.low, site) ==
-      hop_constants[site] * u_low_high.low[species, site]
+    hop_constants[site] * u_low_high.low[species, site]
 @test JP.total_site_hop_rate(hop_rates.high, site) ==
-      hop_constants[site] * u_low_high.high[species, site]
+    hop_constants[site] * u_low_high.high[species, site]

--- a/test/spatial/diffusion.jl
+++ b/test/spatial/diffusion.jl
@@ -10,7 +10,7 @@ function get_mean_sol(jump_prob, Nsims, saveat)
     for i in 1:(Nsims - 1)
         sol += solve(jump_prob, SSAStepper(), saveat = saveat).u
     end
-    sol / Nsims
+    return sol / Nsims
 end
 
 # assume sites are labeled from 1 to num_sites(spatial_system)
@@ -24,7 +24,7 @@ function discrete_laplacian_from_spatial_system(spatial_system, hopping_rate)
         end
     end
     laplacian .*= hopping_rate
-    laplacian
+    return laplacian
 end
 
 # problem setup
@@ -63,43 +63,69 @@ times = 0.0:(tf / num_time_points):tf
 
 algs = [NSM(), DirectCRDirect()]
 grids = [CartesianGridRej(dims), Graphs.grid(dims)]
-jump_problems = JumpProblem[JumpProblem(prob, algs[2], majumps,
-                                hopping_constants = hopping_constants,
-                                spatial_system = grid,
-                                save_positions = (false, false), rng = rng)
-                            for grid in grids]
+jump_problems = JumpProblem[
+    JumpProblem(
+            prob, algs[2], majumps,
+            hopping_constants = hopping_constants,
+            spatial_system = grid,
+            save_positions = (false, false), rng = rng
+        )
+        for grid in grids
+]
 sizehint!(jump_problems, 15 + length(jump_problems))
 
 # flattenned jump prob
-push!(jump_problems,
-    JumpProblem(prob, NRM(), majumps, hopping_constants = hopping_constants,
-        spatial_system = grids[1], save_positions = (false, false), rng = rng))
+push!(
+    jump_problems,
+    JumpProblem(
+        prob, NRM(), majumps, hopping_constants = hopping_constants,
+        spatial_system = grids[1], save_positions = (false, false), rng = rng
+    )
+)
 
 # hop rates of form D_s
 hop_constants = [hopping_rate]
 for alg in algs
-    push!(jump_problems,
-        JumpProblem(prob, alg, majumps, hopping_constants = hop_constants,
-            spatial_system = grids[1], save_positions = (false, false), rng = rng))
-    push!(jump_problems,
-        JumpProblem(prob, alg, majumps, hopping_constants = hop_constants,
-            spatial_system = grids[end], save_positions = (false, false), rng = rng))
+    push!(
+        jump_problems,
+        JumpProblem(
+            prob, alg, majumps, hopping_constants = hop_constants,
+            spatial_system = grids[1], save_positions = (false, false), rng = rng
+        )
+    )
+    push!(
+        jump_problems,
+        JumpProblem(
+            prob, alg, majumps, hopping_constants = hop_constants,
+            spatial_system = grids[end], save_positions = (false, false), rng = rng
+        )
+    )
 end
 
 # hop rates of form L_{s,i,j}
 hop_constants = Matrix{Vector{Float64}}(undef, size(hopping_constants))
 for ci in CartesianIndices(hop_constants)
     (species, site) = Tuple(ci)
-    hop_constants[ci] = repeat([hopping_constants[species, site]],
-        outdegree(grids[1], site))
+    hop_constants[ci] = repeat(
+        [hopping_constants[species, site]],
+        outdegree(grids[1], site)
+    )
 end
 for alg in algs
-    push!(jump_problems,
-        JumpProblem(prob, alg, majumps, hopping_constants = hop_constants,
-            spatial_system = grids[1], save_positions = (false, false), rng = rng))
-    push!(jump_problems,
-        JumpProblem(prob, alg, majumps, hopping_constants = hop_constants,
-            spatial_system = grids[end], save_positions = (false, false), rng = rng))
+    push!(
+        jump_problems,
+        JumpProblem(
+            prob, alg, majumps, hopping_constants = hop_constants,
+            spatial_system = grids[1], save_positions = (false, false), rng = rng
+        )
+    )
+    push!(
+        jump_problems,
+        JumpProblem(
+            prob, alg, majumps, hopping_constants = hop_constants,
+            spatial_system = grids[end], save_positions = (false, false), rng = rng
+        )
+    )
 end
 
 # hop rates of form D_s * L_{i,j}
@@ -109,14 +135,22 @@ for site in 1:num_nodes
     site_hop_constants[site] = repeat([1.0], JumpProcesses.outdegree(grids[1], site))
 end
 for alg in algs
-    push!(jump_problems,
-        JumpProblem(prob, alg, majumps,
+    push!(
+        jump_problems,
+        JumpProblem(
+            prob, alg, majumps,
             hopping_constants = Pair(species_hop_constants, site_hop_constants),
-            spatial_system = grids[1], save_positions = (false, false), rng = rng))
-    push!(jump_problems,
-        JumpProblem(prob, alg, majumps,
+            spatial_system = grids[1], save_positions = (false, false), rng = rng
+        )
+    )
+    push!(
+        jump_problems,
+        JumpProblem(
+            prob, alg, majumps,
             hopping_constants = Pair(species_hop_constants, site_hop_constants),
-            spatial_system = grids[end], save_positions = (false, false), rng = rng))
+            spatial_system = grids[end], save_positions = (false, false), rng = rng
+        )
+    )
 end
 
 # hop rates of form D_{s,i} * L_{i,j}
@@ -126,14 +160,22 @@ for site in 1:num_nodes
     site_hop_constants[site] = repeat([1.0], JumpProcesses.outdegree(grids[1], site))
 end
 for alg in algs
-    push!(jump_problems,
-        JumpProblem(prob, alg, majumps,
+    push!(
+        jump_problems,
+        JumpProblem(
+            prob, alg, majumps,
             hopping_constants = Pair(species_hop_constants, site_hop_constants),
-            spatial_system = grids[1], save_positions = (false, false), rng = rng))
-    push!(jump_problems,
-        JumpProblem(prob, alg, majumps,
+            spatial_system = grids[1], save_positions = (false, false), rng = rng
+        )
+    )
+    push!(
+        jump_problems,
+        JumpProblem(
+            prob, alg, majumps,
             hopping_constants = Pair(species_hop_constants, site_hop_constants),
-            spatial_system = grids[end], save_positions = (false, false), rng = rng))
+            spatial_system = grids[end], save_positions = (false, false), rng = rng
+        )
+    )
 end
 
 # testing
@@ -142,7 +184,7 @@ for (j, spatial_jump_prob) in enumerate(jump_problems)
     for (i, t) in enumerate(times)
         local diff = analytic_solution(t) - reshape(mean_sol[i], num_nodes, 1)
         @test abs(sum(diff[1:center_node]) / sum(analytic_solution(t)[1:center_node])) <
-              rel_tol
+            rel_tol
     end
 end
 
@@ -164,8 +206,10 @@ starting_state = 25 * ones(Int, length(u0), num_nodes)
 tspan = (0.0, 10.0)
 prob = DiscreteProblem(starting_state, tspan)
 
-jp = JumpProblem(prob, NSM(), majumps, hopping_constants = hopping_constants,
-    spatial_system = grid, save_positions = (false, false), rng = rng)
+jp = JumpProblem(
+    prob, NSM(), majumps, hopping_constants = hopping_constants,
+    spatial_system = grid, save_positions = (false, false), rng = rng
+)
 sol = solve(jp, SSAStepper())
 
 @test sol.u[end][1, 1] == sum(sol.u[end])

--- a/test/spatial/hop_rates.jl
+++ b/test/spatial/hop_rates.jl
@@ -13,6 +13,7 @@ function test_reset(hop_rates, num_nodes)
     for site in 1:num_nodes
         @test JP.total_site_hop_rate(hop_rates, site) == 0.0
     end
+    return
 end
 
 function normalized(distribution::Dict)
@@ -26,8 +27,10 @@ end
 
 normalized(distribution) = distribution / sum(distribution)
 
-function statistical_test(hop_rates, spec_propensities, target_propensities::Dict,
-        num_species, u, site, g, rng, rel_tol)
+function statistical_test(
+        hop_rates, spec_propensities, target_propensities::Dict,
+        num_species, u, site, g, rng, rel_tol
+    )
     spec_probs = normalized(spec_propensities)
     target_probs = normalized(target_propensities)
     JP.update_hop_rates!(hop_rates, 1:num_species, u, site, g)
@@ -45,6 +48,7 @@ function statistical_test(hop_rates, spec_propensities, target_propensities::Dic
     for target in JP.neighbors(g, site)
         @test abs(site_dict[target]) / num_samples - target_probs[target] < rel_tol
     end
+    return
 end
 
 io = IOBuffer()
@@ -68,8 +72,10 @@ for site in 1:num_nodes
     for (i, target) in enumerate(JP.neighbors(g, site))
         target_propensities[target] = 1.0
     end
-    statistical_test(hop_rates, spec_propensities, target_propensities, num_species, u,
-        site, g, rng, rel_tol)
+    statistical_test(
+        hop_rates, spec_propensities, target_propensities, num_species, u,
+        site, g, rng, rel_tol
+    )
 end
 test_reset(hop_rates, num_nodes)
 
@@ -84,8 +90,10 @@ for site in 1:num_nodes
     for (i, target) in enumerate(JP.neighbors(g, site))
         target_propensities[target] = 1.0
     end
-    statistical_test(hop_rates, spec_propensities, target_propensities, num_species, u,
-        site, g, rng, rel_tol)
+    statistical_test(
+        hop_rates, spec_propensities, target_propensities, num_species, u,
+        site, g, rng, rel_tol
+    )
 end
 test_reset(hop_rates, num_nodes)
 
@@ -97,7 +105,7 @@ hop_constants[1, :] = [
     [1.0, 2.0],
     [1.0, 2.0],
     [1.0, 2.0, 4.0],
-    [1.0, 2.0]
+    [1.0, 2.0],
 ]
 hop_constants[2, :] = [
     [3.0, 12.0],
@@ -105,11 +113,11 @@ hop_constants[2, :] = [
     [3.0, 6.0],
     [3.0, 6.0],
     [3.0, 6.0, 12.0],
-    [3.0, 6.0]
+    [3.0, 6.0],
 ]
 hop_rates_structs = [
     JP.HopRatesGraphDsij(hop_constants),
-    JP.HopRates(hop_constants, g)
+    JP.HopRates(hop_constants, g),
 ]
 @test hop_rates_structs[2] isa JP.HopRatesGridDsij
 for hop_rates in hop_rates_structs
@@ -118,8 +126,12 @@ for hop_rates in hop_rates_structs
         spec_propensities = [sum(hop_constants[species, site]) for species in 1:num_species]
         target_propensities = Dict{Int, Float64}()
         for (i, target) in enumerate(JP.neighbors(g, site))
-            target_propensities[target] = sum([hop_constants[species, site][i]
-                                               for species in 1:num_species])
+            target_propensities[target] = sum(
+                [
+                    hop_constants[species, site][i]
+                        for species in 1:num_species
+                ]
+            )
         end
         statistical_test(hop_rates, spec_propensities, target_propensities, num_species, u, site, g, rng, rel_tol)
     end
@@ -134,23 +146,29 @@ site_hop_constants = [
     [1.0, 2.0],
     [1.0, 2.0],
     [1.0, 2.0, 4.0],
-    [1.0, 2.0]
+    [1.0, 2.0],
 ] #[site][target_site]
 hop_rates_structs = [
     JP.HopRatesGraphDsLij(species_hop_constants, site_hop_constants),
-    JP.HopRates((species_hop_constants => site_hop_constants), g)
+    JP.HopRates((species_hop_constants => site_hop_constants), g),
 ]
 @test hop_rates_structs[2] isa JP.HopRatesGridDsLij
 for hop_rates in hop_rates_structs
     show(io, "text/plain", hop_rates)
     for site in 1:num_nodes
-        spec_propensities = [species_hop_constants[species] * sum(site_hop_constants[site])
-                             for species in 1:num_species]
+        spec_propensities = [
+            species_hop_constants[species] * sum(site_hop_constants[site])
+                for species in 1:num_species
+        ]
         target_propensities = Dict{Int, Float64}()
         for (i, target) in enumerate(JP.neighbors(g, site))
-            target_propensities[target] = sum([species_hop_constants[species] *
-                                               site_hop_constants[site][i]
-                                               for species in 1:num_species])
+            target_propensities[target] = sum(
+                [
+                    species_hop_constants[species] *
+                        site_hop_constants[site][i]
+                        for species in 1:num_species
+                ]
+            )
         end
         statistical_test(hop_rates, spec_propensities, target_propensities, num_species, u, site, g, rng, rel_tol)
     end
@@ -165,11 +183,11 @@ site_hop_constants = [
     [1.0, 2.0],
     [1.0, 2.0],
     [1.0, 2.0, 4.0],
-    [1.0, 2.0]
+    [1.0, 2.0],
 ] #[site][target_site]
 hop_rates_structs = [
     JP.HopRatesGraphDsiLij(species_hop_constants, site_hop_constants),
-    JP.HopRates((species_hop_constants => site_hop_constants), g)
+    JP.HopRates((species_hop_constants => site_hop_constants), g),
 ]
 @test hop_rates_structs[2] isa JP.HopRatesGridDsiLij
 for hop_rates in hop_rates_structs
@@ -178,9 +196,13 @@ for hop_rates in hop_rates_structs
         spec_propensities = [species_hop_constants[species, site] * sum(site_hop_constants[site]) for species in 1:num_species]
         target_propensities = Dict{Int, Float64}()
         for (i, target) in enumerate(JP.neighbors(g, site))
-            target_propensities[target] = sum([species_hop_constants[species, site] *
-                                               site_hop_constants[site][i]
-                                               for species in 1:num_species])
+            target_propensities[target] = sum(
+                [
+                    species_hop_constants[species, site] *
+                        site_hop_constants[site][i]
+                        for species in 1:num_species
+                ]
+            )
         end
         statistical_test(hop_rates, spec_propensities, target_propensities, num_species, u, site, g, rng, rel_tol)
     end

--- a/test/spatial/topology.jl
+++ b/test/spatial/topology.jl
@@ -17,7 +17,7 @@ num_samples = 10^5
 rel_tol = 0.01
 grids = [
     JP.CartesianGridRej(dims),
-    Graphs.grid(dims)
+    Graphs.grid(dims),
 ]
 for grid in grids
     show(io, "text/plain", grid)
@@ -30,7 +30,7 @@ for grid in grids
     @test JP.outdegree(grid, 6) == 5
     for site in sites
         @test [JP.nth_nbr(grid, site, n) for n in 1:outdegree(grid, site)] ==
-              collect(neighbors(grid, site))
+            collect(neighbors(grid, site))
         d = Dict{Int, Int}()
         for i in 1:num_samples
             nb = JP.rand_nbr(rng, grid, site)

--- a/test/splitcoupled.jl
+++ b/test/splitcoupled.jl
@@ -5,7 +5,7 @@ rng = StableRNG(12345)
 
 rate = (u, p, t) -> 1.0 * u[1]
 affect! = function (integrator)
-    integrator.u[1] = 1.0
+    return integrator.u[1] = 1.0
 end
 jump1 = ConstantRateJump(rate, affect!)
 
@@ -18,7 +18,8 @@ jump_prob_control = JumpProblem(prob_control, Direct(), jump1; rng = rng)
 coupling_map = [(1, 1)]
 coupled_prob = SplitCoupledJumpProblem(
     jump_prob, jump_prob_control, Direct(), coupling_map;
-    rng = rng)
+    rng = rng
+)
 
 @time sol = solve(coupled_prob, FunctionMap())
 @time solve(jump_prob, FunctionMap())
@@ -26,17 +27,17 @@ coupled_prob = SplitCoupledJumpProblem(
 
 rate = (u, p, t) -> 1.0
 affect! = function (integrator)
-    integrator.u[1] = 1.0
+    return integrator.u[1] = 1.0
 end
 jump1 = ConstantRateJump(rate, affect!)
 rate = (u, p, t) -> 2.0
 jump2 = ConstantRateJump(rate, affect!)
 
 f = function (du, u, p, t)
-    du[1] = u[1]
+    return du[1] = u[1]
 end
 g = function (du, u, p, t)
-    du[1] = 0.1
+    return du[1] = 0.1
 end
 
 # Jump ODE to jump ODE
@@ -46,7 +47,8 @@ jump_prob = JumpProblem(prob, Direct(), jump1; rng = rng)
 jump_prob_control = JumpProblem(prob_control, Direct(), jump2; rng = rng)
 coupled_prob = SplitCoupledJumpProblem(
     jump_prob, jump_prob_control, Direct(), coupling_map;
-    rng = rng)
+    rng = rng
+)
 sol = solve(coupled_prob, Tsit5())
 @test mean([abs(s[1] - s[2]) for s in sol.u]) <= 5.0
 
@@ -57,7 +59,8 @@ jump_prob = JumpProblem(prob, Direct(), jump1; rng = rng)
 jump_prob_control = JumpProblem(prob_control, Direct(), jump1; rng = rng)
 coupled_prob = SplitCoupledJumpProblem(
     jump_prob, jump_prob_control, Direct(), coupling_map;
-    rng = rng)
+    rng = rng
+)
 sol = solve(coupled_prob, SRIW1())
 @test mean([abs(s[1] - s[2]) for s in sol.u]) <= 5.0
 
@@ -68,14 +71,15 @@ jump_prob = JumpProblem(prob, Direct(), jump1; rng = rng)
 jump_prob_control = JumpProblem(prob_control, Direct(), jump1; rng = rng)
 coupled_prob = SplitCoupledJumpProblem(
     jump_prob, jump_prob_control, Direct(), coupling_map;
-    rng = rng)
+    rng = rng
+)
 sol = solve(coupled_prob, SRIW1())
 @test mean([abs(s[1] - s[2]) for s in sol.u]) <= 5.0
 
 # Jump SDE to Discrete
 rate = (u, p, t) -> 1.0
 affect! = function (integrator)
-    integrator.u[1] += 1.0
+    return integrator.u[1] += 1.0
 end
 prob = DiscreteProblem([1.0], (0.0, 1.0))
 prob_control = SDEProblem(f, g, [1.0], (0.0, 1.0))
@@ -83,7 +87,8 @@ jump_prob = JumpProblem(prob, Direct(), jump1; rng = rng)
 jump_prob_control = JumpProblem(prob_control, Direct(), jump1; rng = rng)
 coupled_prob = SplitCoupledJumpProblem(
     jump_prob, jump_prob_control, Direct(), coupling_map;
-    rng = rng)
+    rng = rng
+)
 sol = solve(coupled_prob, SRIW1())
 
 # test mass action jumps coupled to ODE
@@ -93,11 +98,13 @@ react_stoch = [Vector{Pair{Int, Int}}()]
 net_stoch = [[1 => 1]]
 majumps = MassActionJump(rate, react_stoch, net_stoch)
 f = function (du, u, p, t)
-    du[1] = -1.0 * u[1]
+    return du[1] = -1.0 * u[1]
 end
 odeprob = ODEProblem(f, [10.0], (0.0, 10.0))
-jump_prob = JumpProblem(odeprob, Direct(), majumps, save_positions = (false, false);
-    rng = rng)
+jump_prob = JumpProblem(
+    odeprob, Direct(), majumps, save_positions = (false, false);
+    rng = rng
+)
 Nsims = 8000
 Amean = 0.0
 for i in 1:Nsims

--- a/test/ssa_tests.jl
+++ b/test/ssa_tests.jl
@@ -5,13 +5,13 @@ rng = StableRNG(12345)
 
 rate = (u, p, t) -> u[1]
 affect! = function (integrator)
-    integrator.u[1] += 1
+    return integrator.u[1] += 1
 end
 jump = ConstantRateJump(rate, affect!)
 
 rate = (u, p, t) -> 0.5u[1]
 affect! = function (integrator)
-    integrator.u[1] -= 1
+    return integrator.u[1] -= 1
 end
 jump2 = ConstantRateJump(rate, affect!)
 
@@ -37,8 +37,10 @@ sol = solve(jump_prob, SSAStepper(), save_start = false)
 @test sol.t[begin] > 0.0
 @test sol.t[end] == 3.0
 
-jump_prob = JumpProblem(prob, Direct(), jump, jump2, save_positions = (false, false);
-    rng = rng)
+jump_prob = JumpProblem(
+    prob, Direct(), jump, jump2, save_positions = (false, false);
+    rng = rng
+)
 sol = solve(jump_prob, SSAStepper(), save_start = false, save_end = false)
 @test isempty(sol.t) && isempty(sol.u)
 

--- a/test/table_test.jl
+++ b/test/table_test.jl
@@ -3,9 +3,9 @@ using Test
 const DJ = JumpProcesses
 
 # test data
-minpriority = 2.0^exponent(1e-12)
-maxpriority = 2.0^exponent(1e12)
-priorities = [1e-13, 0.99 * minpriority, minpriority, 1.01e-4, 1e-4, 5.0, 0.0, 1e10]
+minpriority = 2.0^exponent(1.0e-12)
+maxpriority = 2.0^exponent(1.0e12)
+priorities = [1.0e-13, 0.99 * minpriority, minpriority, 1.01e-4, 1.0e-4, 5.0, 0.0, 1.0e10]
 
 mingid = exponent(minpriority)   # = -40
 ptog = priority -> DJ.priortogid(priority, mingid)
@@ -54,7 +54,7 @@ priorities[10] = 0.0
 
 # test sampling
 cnt = 0
-Nsamps = Int(1e7)
+Nsamps = Int(1.0e7)
 for i in 1:Nsamps
     global cnt
     pid = DJ.sample(pt, priorities)
@@ -76,7 +76,7 @@ ptt = DJ.PriorityTimeTable(times, mintime, timestep)
 DJ.update!(ptt, 1, times[1], 10 * times[1]) # 2. -> 20., group 2 to group 14
 @test ptt.groups[14].numpids == 1
 @test DJ.getfirst(ptt) == (2, 8.0)
-# Updating beyond the time window should not change the max priority. 
+# Updating beyond the time window should not change the max priority.
 DJ.update!(ptt, 1, times[1], 70.0) # 20. -> 70.
 @test ptt.groups[14].numpids == 0
 @test ptt.maxtime == 66.0

--- a/test/thread_safety.jl
+++ b/test/thread_safety.jl
@@ -11,14 +11,16 @@ u0 = [5]
 dprob = DiscreteProblem(u0, tspan, params)
 jprob = JumpProblem(dprob, Direct(), maj; rng = rng)
 solve(EnsembleProblem(jprob), SSAStepper(), EnsembleThreads(); trajectories = 10)
-solve(EnsembleProblem(jprob; safetycopy = true), SSAStepper(), EnsembleThreads();
-    trajectories = 10)
+solve(
+    EnsembleProblem(jprob; safetycopy = true), SSAStepper(), EnsembleThreads();
+    trajectories = 10
+)
 
 # test for https://github.com/SciML/JumpProcesses.jl/issues/472
 let
     function f!(du, u, p, t)
         du[1] = -u[1]
-        nothing
+        return nothing
     end
     u_0 = [1.0]
     ode_prob = ODEProblem(f!, u_0, (0.0, 10))
@@ -28,8 +30,10 @@ let
         jump_prob = JumpProblem(ode_prob, Direct(), vrj; vr_aggregator = agg)
         prob_func(prob, i, repeat) = deepcopy(prob)
         prob = EnsembleProblem(jump_prob, prob_func = prob_func)
-        sol = solve(prob, Tsit5(), EnsembleThreads(), trajectories = 400,
-            save_everystep = false)
+        sol = solve(
+            prob, Tsit5(), EnsembleThreads(), trajectories = 400,
+            save_everystep = false
+        )
         firstrx_time = [sol.u[i].t[2] for i in 1:length(sol)]
         @test allunique(firstrx_time)
     end

--- a/test/variable_rate.jl
+++ b/test/variable_rate.jl
@@ -26,7 +26,7 @@ jump = VariableRateJump(rate, affect!, interp_points = 1000)
 jump2 = deepcopy(jump)
 
 f = function (du, u, p, t)
-    du[1] = u[1]
+    return du[1] = u[1]
 end
 
 prob = ODEProblem(f, [0.2], (0.0, 10.0))
@@ -41,22 +41,22 @@ integrator = init(jump_prob_gill, Tsit5())
 sol_gill = solve(jump_prob_gill, Tsit5())
 sol_gill = solve(jump_prob, Rosenbrock23(autodiff = AutoFiniteDiff()))
 sol_gill = solve(jump_prob, Rosenbrock23())
-@test maximum([sol.u[i][2] for i in 1:length(sol)]) <= 1e-12
-@test maximum([sol.u[i][3] for i in 1:length(sol)]) <= 1e-12
+@test maximum([sol.u[i][2] for i in 1:length(sol)]) <= 1.0e-12
+@test maximum([sol.u[i][3] for i in 1:length(sol)]) <= 1.0e-12
 
 g = function (du, u, p, t)
-    du[1] = u[1]
+    return du[1] = u[1]
 end
 prob = SDEProblem(f, g, [0.2], (0.0, 10.0))
 jump_prob = JumpProblem(prob, jump, jump2; vr_aggregator = VR_FRM(), rng = rng)
 sol = solve(jump_prob, SRIW1())
 jump_prob_gill = JumpProblem(prob, jump, jump2; vr_aggregator = VR_Direct(), rng = rng)
 sol_gill = solve(jump_prob_gill, SRIW1())
-@test maximum([sol.u[i][2] for i in 1:length(sol)]) <= 1e-12
-@test maximum([sol.u[i][3] for i in 1:length(sol)]) <= 1e-12
+@test maximum([sol.u[i][2] for i in 1:length(sol)]) <= 1.0e-12
+@test maximum([sol.u[i][3] for i in 1:length(sol)]) <= 1.0e-12
 
 function ff(du, u, p, t)
-    if p == 0
+    return if p == 0
         du .= 1.01u
     else
         du .= 2.01u
@@ -66,11 +66,11 @@ function gg(du, u, p, t)
     du[1, 1] = 0.3u[1]
     du[1, 2] = 0.6u[1]
     du[2, 1] = 1.2u[1]
-    du[2, 2] = 0.2u[2]
+    return du[2, 2] = 0.2u[2]
 end
 rate_switch(u, p, t) = u[1] * 1.0
 function affect_switch!(integrator)
-    integrator.p = 1
+    return integrator.p = 1
 end
 jump_switch = VariableRateJump(rate_switch, affect_switch!)
 prob = SDEProblem(ff, gg, ones(2), (0.0, 1.0), 0, noise_rate_prototype = zeros(2, 2))
@@ -82,7 +82,7 @@ sol_gill = solve(jump_prob_gill, SRA1(), dt = 1.0)
 ## Some integration tests
 
 function f2(du, u, p, t)
-    du[1] = u[1]
+    return du[1] = u[1]
 end
 prob = ODEProblem(f2, [0.2], (0.0, 10.0))
 rate2(u, p, t) = 2
@@ -107,7 +107,7 @@ sol(4.0)
 sol.u[4]
 
 function g2(du, u, p, t)
-    du[1] = u[1]
+    return du[1] = u[1]
 end
 prob = SDEProblem(f2, g2, [0.2], (0.0, 10.0))
 jump_prob = JumpProblem(prob, jump, jump2; vr_aggregator = VR_FRM(), rng)
@@ -118,15 +118,17 @@ sol(4.0)
 sol.u[4]
 
 function f3(du, u, p, t)
-    du .= u
+    return du .= u
 end
 prob = ODEProblem(f3, [1.0 2.0; 3.0 4.0], (0.0, 1.0))
 rate3(u, p, t) = u[1] + u[2]
 function affect3!(integrator)
-    (integrator.u[1] = 0.25;
+    (
+        integrator.u[1] = 0.25;
         integrator.u[2] = 0.5;
         integrator.u[3] = 0.75;
-        integrator.u[4] = 1)
+        integrator.u[4] = 1
+    )
 end
 jump = VariableRateJump(rate3, affect3!)
 jump_prob = JumpProblem(prob, jump; vr_aggregator = VR_FRM(), rng)
@@ -136,11 +138,11 @@ sol_gill = solve(jump_prob_gill, Tsit5())
 
 # test for https://discourse.julialang.org/t/differentialequations-jl-package-variable-rate-jumps-with-complex-variables/80366/2
 function f4(dx, x, p, t)
-    dx[1] = x[1]
+    return dx[1] = x[1]
 end
 rate4(x, p, t) = t
 function affect4!(integrator)
-    integrator.u[1] = integrator.u[1] * 0.5
+    return integrator.u[1] = integrator.u[1] * 0.5
 end
 jump = VariableRateJump(rate4, affect4!)
 x₀ = 1.0 + 0.0im
@@ -166,11 +168,13 @@ let
     maj_rate = [1.0]
     react_stoich_ = [Vector{Pair{Int, Int}}()]
     net_stoich_ = [[1 => 1]]
-    mass_action_jump_ = MassActionJump(maj_rate, react_stoich_, net_stoich_;
-        scale_rates = false)
+    mass_action_jump_ = MassActionJump(
+        maj_rate, react_stoich_, net_stoich_;
+        scale_rates = false
+    )
 
     affect! = function (integrator)
-        integrator.u[1] -= 1
+        return integrator.u[1] -= 1
     end
     cs_rate1(u, p, t) = 0.2 * u[1]
     constant_rate_jump = ConstantRateJump(cs_rate1, affect!)
@@ -180,13 +184,19 @@ let
         u0 = [0]
         tspan = (0.0, 30.0)
         dprob_ = DiscreteProblem(u0, tspan)
-        @test_throws ErrorException JumpProblem(dprob_, alg, jumpset_,
-            save_positions = (false, false))
+        @test_throws ErrorException JumpProblem(
+            dprob_, alg, jumpset_,
+            save_positions = (false, false)
+        )
 
-        vrj = VariableRateJump(cs_rate1, affect!; urate = ((u, p, t) -> 1.0),
-            rateinterval = ((u, p, t) -> 1.0))
-        @test_throws ErrorException JumpProblem(dprob_, alg, mass_action_jump_, vrj;
-            save_positions = (false, false))
+        vrj = VariableRateJump(
+            cs_rate1, affect!; urate = ((u, p, t) -> 1.0),
+            rateinterval = ((u, p, t) -> 1.0)
+        )
+        @test_throws ErrorException JumpProblem(
+            dprob_, alg, mass_action_jump_, vrj;
+            save_positions = (false, false)
+        )
     end
 end
 
@@ -216,8 +226,10 @@ let
         end
     end
 
-    test_jump = VariableRateJump(test_rate, test_affect!; urate = test_urate,
-        rateinterval = (u, p, t) -> 1.0)
+    test_jump = VariableRateJump(
+        test_rate, test_affect!; urate = test_urate,
+        rateinterval = (u, p, t) -> 1.0
+    )
 
     dprob = DiscreteProblem([0], (0.0, 1.0), nothing)
     jprob = JumpProblem(dprob, Coevolve(), test_jump; dep_graph = [[1]])
@@ -239,19 +251,19 @@ let
 
     function ode_fxn(du, u, p, t)
         du .= 0
-        nothing
+        return nothing
     end
     b_rate(u, p, t) = (u[1] * p[1])
     function birth!(integrator)
         integrator.u[1] += 1
-        nothing
+        return nothing
     end
     b_jump = VariableRateJump(b_rate, birth!)
 
     d_rate(u, p, t) = (u[1] * p[2])
     function death!(integrator)
         integrator.u[1] -= 1
-        nothing
+        return nothing
     end
     d_jump = VariableRateJump(d_rate, death!)
 
@@ -267,9 +279,9 @@ let
     end
 end
 
-# accuracy test based on 
+# accuracy test based on
 # https://github.com/SciML/JumpProcesses.jl/issues/320
-# note that even with the seeded StableRNG this test is not 
+# note that even with the seeded StableRNG this test is not
 # deterministic for some reason.
 function getmean(Nsims, prob, alg, dt, tsave, seed)
     umean = zeros(length(tsave))
@@ -296,20 +308,20 @@ let
 
     function ode_fxn(du, u, p, t)
         du .= 0
-        nothing
+        return nothing
     end
 
     b_rate(u, p, t) = (u[1] * p[1])
     function birth!(integrator)
         integrator.u[1] += 1
-        nothing
+        return nothing
     end
     b_jump = VariableRateJump(b_rate, birth!)
 
     d_rate(u, p, t) = (u[1] * p[2])
     function death!(integrator)
         integrator.u[1] -= 1
-        nothing
+        return nothing
     end
     d_jump = VariableRateJump(d_rate, death!)
 
@@ -327,7 +339,7 @@ let
     end
 end
 
-# Correctness test based on 
+# Correctness test based on
 # VR_Direct and VR_FRM
 # Function to run ensemble and compute statistics
 function run_ensemble(prob, alg, jumps...; vr_aggregator = VR_FRM(), Nsims = 8000)
@@ -391,7 +403,7 @@ let
 
     t = 10.0
     u0 = 0.2
-    analytical_mean = u0 * exp(-t) + λ*(1 - exp(-t))
+    analytical_mean = u0 * exp(-t) + λ * (1 - exp(-t))
 
     @test isapprox(mean_vrfr, analytical_mean, rtol = 0.05)
     @test isapprox(mean_vrfr, mean_vrcb, rtol = 0.05)
@@ -407,7 +419,7 @@ let
     function birth_affect!(integrator)
         integrator.u[1] += 1
         integrator.p[3] += 1
-        nothing
+        return nothing
     end
     birth_jump = VariableRateJump(birth_rate, birth_affect!)
 
@@ -416,7 +428,7 @@ let
     function death_affect!(integrator)
         integrator.u[1] -= 1
         integrator.p[3] += 1
-        nothing
+        return nothing
     end
     death_jump = VariableRateJump(death_rate, death_affect!)
 


### PR DESCRIPTION
## Summary
- Updated CI workflow to use `fredrikekre/runic-action@v1` instead of JuliaFormatter
- Removed `.JuliaFormatter.toml` configuration file
- Reformatted all source files with Runic.jl

## Changes
This PR migrates the code formatting from JuliaFormatter with SciMLStyle to Runic.jl. Runic.jl is an opinionated formatter (similar to Go's gofmt) that requires no configuration.

Key differences from JuliaFormatter:
- Explicit `return` statements are added where implicit
- Different indentation and alignment for continuation lines
- Consistent multiline formatting for function arguments

## Test plan
- [ ] CI format check passes with Runic.jl
- [ ] All existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)