### PR TITLE
Stop reseeding RNG on every solve call (fixes #464)

### DIFF
--- a/src/SSA_stepper.jl
+++ b/src/SSA_stepper.jl
@@ -225,11 +225,11 @@ function DiffEqBase.__init(jump_prob::JumpProblem,
         end
     else
         cb = deepcopy(jump_prob.jump_callback.discrete_callbacks[end])
-        rng = cb.condition.rng
-        if seed === nothing
-            Random.seed!(rng, rand(UInt64))
-        else
-            Random.seed!(rng, seed)
+        # Only reseed if an explicit seed is provided. This respects the user's RNG choice
+        # and enables reproducibility. For EnsembleProblems, use prob_func to set unique seeds
+        # for each trajectory if different results are needed.
+        if seed !== nothing
+            Random.seed!(cb.condition.rng, seed)
         end
     end
     opts = (callback = CallbackSet(callback),)

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -67,13 +67,12 @@ end
 
 function resetted_jump_problem(_jump_prob, seed)
     jump_prob = deepcopy(_jump_prob)
-    if !isempty(jump_prob.jump_callback.discrete_callbacks)
+    # Only reseed if an explicit seed is provided. This respects the user's RNG choice
+    # and enables reproducibility. For EnsembleProblems, use prob_func to set unique seeds
+    # for each trajectory if different results are needed.
+    if seed !== nothing && !isempty(jump_prob.jump_callback.discrete_callbacks)
         rng = jump_prob.jump_callback.discrete_callbacks[1].condition.rng
-        if seed === nothing
-            Random.seed!(rng, rand(UInt64))
-        else
-            Random.seed!(rng, seed)
-        end
+        Random.seed!(rng, seed)
     end
 
     if !isempty(jump_prob.variable_jumps) && jump_prob.prob.u0 isa ExtendedJumpArray

--- a/test/ensemble_uniqueness.jl
+++ b/test/ensemble_uniqueness.jl
@@ -1,19 +1,41 @@
 using OrdinaryDiffEq, JumpProcesses, Test
-using StableRNGs
-rng = StableRNG(12345)
+using StableRNGs, Random
 
 j1 = ConstantRateJump((u, p, t) -> 10, (integrator) -> integrator.u[1] += 1)
 j2 = ConstantRateJump((u, p, t) -> 1u[1], (integrator) -> integrator.u[1] -= 1)
 u0 = [0]
 
-prob = DiscreteProblem(u0, (0.0, 100.0))
-jump_prob = JumpProblem(prob, Direct(), j1, j2; rng = rng)
-sol = solve(EnsembleProblem(jump_prob), FunctionMap(), trajectories = 3)
+dprob = DiscreteProblem(u0, (0.0, 100.0))
+
+# For EnsembleProblems, use prob_func to create a new JumpProblem with unique RNG per trajectory.
+# This ensures different trajectories while maintaining reproducibility.
+# Generate seeds from a seeded RNG for reproducibility of ensemble results.
+function make_seeded_prob_func(dprob, aggregator, jumps, base_rng)
+    return function prob_func(prob, i, repeat)
+        seed = rand(base_rng, UInt64)
+        JumpProblem(dprob, aggregator, jumps...; rng = StableRNG(seed))
+    end
+end
+
+# Test with FunctionMap - use prob_func to create JumpProblems with unique RNGs
+rng1 = StableRNG(12345)
+jump_prob = JumpProblem(dprob, Direct(), j1, j2; rng = rng1)
+ensemble_rng = StableRNG(99999)  # separate RNG for generating trajectory seeds
+ensemble_prob = EnsembleProblem(jump_prob;
+    prob_func = make_seeded_prob_func(dprob, Direct(), (j1, j2), ensemble_rng))
+sol = solve(ensemble_prob, FunctionMap(), trajectories = 3)
 @test Array(sol.u[1]) !== Array(sol.u[2])
 @test Array(sol.u[1]) !== Array(sol.u[3])
 @test Array(sol.u[2]) !== Array(sol.u[3])
 @test eltype(sol.u[1].u[1]) == Int
-sol = solve(EnsembleProblem(jump_prob), SSAStepper(), trajectories = 3)
+
+# Test with SSAStepper - use prob_func to create JumpProblems with unique RNGs
+rng2 = StableRNG(12345)
+jump_prob = JumpProblem(dprob, Direct(), j1, j2; rng = rng2)
+ensemble_rng2 = StableRNG(99999)  # separate RNG for generating trajectory seeds
+ensemble_prob2 = EnsembleProblem(jump_prob;
+    prob_func = make_seeded_prob_func(dprob, Direct(), (j1, j2), ensemble_rng2))
+sol = solve(ensemble_prob2, SSAStepper(), trajectories = 3)
 @test Array(sol.u[1]) !== Array(sol.u[2])
 @test Array(sol.u[1]) !== Array(sol.u[3])
 @test Array(sol.u[2]) !== Array(sol.u[3])


### PR DESCRIPTION
## Summary

This PR implements the change requested in #464 - stopping the automatic reseeding of the RNG on every call to `solve`.

### Problem

Previously, JumpProcesses would reseed the RNG with `rand(UInt64)` on every call to `solve` when:
- `seed === nothing` (no explicit seed provided)
- `alias_jump == false` (i.e., when not on the main thread, or when deepcopying the problem)

This led to **non-reproducible results** because it didn't respect the user's RNG choice.

### Solution

- Modified `resetted_jump_problem` in `src/solve.jl` to only reseed when an explicit seed is provided
- Modified `DiffEqBase.__init` in `src/SSA_stepper.jl` similarly
- Updated `test/ensemble_uniqueness.jl` to use `prob_func` with explicit seeds for each trajectory

### Breaking Change

This is a **breaking change** as noted in #464. For `EnsembleProblem`s that require different trajectories, users should now use `prob_func` to set unique seeds for each trajectory. This gives users full control over reproducibility.

Example of the new pattern for EnsembleProblems:
```julia
using JumpProcesses, StableRNGs

function make_seeded_prob_func(dprob, aggregator, jumps, base_rng)
    return function prob_func(prob, i, repeat)
        seed = rand(base_rng, UInt64)
        JumpProblem(dprob, aggregator, jumps...; rng = StableRNG(seed))
    end
end

# Create JumpProblem
jump_prob = JumpProblem(dprob, Direct(), j1, j2)

# Create EnsembleProblem with unique RNG per trajectory
ensemble_rng = StableRNG(99999)  # seeded for reproducibility
ensemble_prob = EnsembleProblem(jump_prob;
    prob_func = make_seeded_prob_func(dprob, Direct(), (j1, j2), ensemble_rng))
sol = solve(ensemble_prob, SSAStepper(), trajectories = 10)
```

## Test plan

- [x] All existing tests pass (verified locally)
- [x] Updated `test/ensemble_uniqueness.jl` to demonstrate the new pattern
- [ ] CI should pass

Fixes #464

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)