### PR TITLE
Disable downgrade tests pending OrdinaryDiffEq updates

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -12,6 +12,7 @@ on:
       - 'docs/**'
 jobs:
   test:
+    if: false  # Disabled: waiting on OrdinaryDiffEq updates. See issue for details.
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
## Summary

- Disables the downgrade CI tests by adding `if: false` to the job in `.github/workflows/Downgrade.yml`

## Motivation

The downgrade tests likely need to wait for updates in OrdinaryDiffEq before they can pass again. This PR temporarily disables them to unblock CI.

## Related

See https://github.com/SciML/JumpProcesses.jl/issues/541 for tracking re-enablement of these tests.

See https://github.com/SciML/DelayDiffEq.jl/pull/357 for similar change in DelayDiffEq.jl.

## Test plan

- [x] CI should skip the downgrade workflow
- [ ] Other CI workflows should still run normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)