### PR TITLE
Exclude QA tests from All group for downstream testing compatibility

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -29,6 +29,10 @@ jobs:
         group:
           - InterfaceI
           - InterfaceII
+          - QA
+        exclude:
+          - version: "pre"
+            group: QA
     uses: "SciML/.github/.github/workflows/tests.yml@v1"
     with:
       julia-version: "${{ matrix.version }}"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,7 +10,7 @@ function activate_gpu_env()
 end
 
 @time begin
-    if GROUP == "All" || GROUP == "QA"
+    if GROUP == "QA"
         @time @safetestset "QA Tests" begin include("qa.jl") end
     end
     


### PR DESCRIPTION
## Summary
- Modified `test/runtests.jl` to only run QA tests when `GROUP="QA"` (not when `GROUP="All"`)
- Added QA to CI test matrix in `Tests.yml`
- Excluded QA tests from Julia `"pre"` version to avoid prerelease compatibility issues

Aqua tests do not work properly in downstream testing scenarios, so QA tests should only run when explicitly requested.

## Test plan
- [ ] Verify CI passes for InterfaceI, InterfaceII groups on all Julia versions
- [ ] Verify QA tests run correctly on Julia 1 and lts versions
- [ ] Verify QA tests are skipped on Julia pre version

🤖 Generated with [Claude Code](https://claude.com/claude-code)