### PR TITLE
Remove stale explicit imports to fix QA tests

### DIFF
--- a/src/JumpProcesses.jl
+++ b/src/JumpProcesses.jl
@@ -4,7 +4,7 @@ using Reexport: Reexport, @reexport
 @reexport using DiffEqBase
 
 # Explicit imports from standard libraries
-using LinearAlgebra: LinearAlgebra, I, mul!
+using LinearAlgebra: LinearAlgebra, mul!
 using Random: Random, randexp, randexp!
 
 # Explicit imports from external packages
@@ -14,10 +14,10 @@ using PoissonRandom: PoissonRandom, pois_rand
 using ArrayInterface: ArrayInterface
 using FunctionWrappers: FunctionWrappers
 using Graphs: Graphs, AbstractGraph, dst, grid, src
-using StaticArrays: StaticArrays, SA, SVector, @SVector, setindex
-using Base.Threads: Threads, @threads
+using StaticArrays: StaticArrays, SVector, setindex
+using Base.Threads: Threads
 using Base.FastMath: add_fast
-using Setfield: @set, @set!
+using Setfield: @set!
 
 # Import functions we extend from Base
 import Base: size, getindex, setindex!, length, similar, show, merge!, merge


### PR DESCRIPTION
## Summary
- Removed unused explicit imports that were causing ExplicitImports.jl QA test failures:
  - `I` from LinearAlgebra (identity matrix)
  - `SA` and `@SVector` from StaticArrays
  - `@threads` from Base.Threads
  - `@set` from Setfield (only `@set!` is actually used)

## Test plan
- [x] QA tests pass locally
- [ ] Verify CI passes for all test groups

🤖 Generated with [Claude Code](https://claude.com/claude-code)