### PR TITLE
Fix method overwrite warning in variable_rate tests

### DIFF
--- a/test/variable_rate.jl
+++ b/test/variable_rate.jl
@@ -96,8 +96,8 @@ sol(4.0)
 sol.u[4]
 
 rate2b(u, p, t) = u[1]
-affect2!(integrator) = (integrator.u[1] = integrator.u[1] / 2)
-jump = VariableRateJump(rate2b, affect2!)
+affect2b!(integrator) = (integrator.u[1] = integrator.u[1] / 2)
+jump = VariableRateJump(rate2b, affect2b!)
 jump2 = deepcopy(jump)
 jump_prob = JumpProblem(prob, jump, jump2; vr_aggregator = VR_FRM(), rng)
 jump_prob_gill = JumpProblem(prob, jump, jump2; vr_aggregator = VR_Direct(), rng)


### PR DESCRIPTION
## Summary
- Rename `affect2!` to `affect2b!` at line 99 of `test/variable_rate.jl` to avoid overwriting the identically-named function defined at line 89
- This eliminates the `WARNING: Method definition affect2!(Any) overwritten` warning that appears in all InterfaceI CI runs (LTS, stable, and pre-release)

## Context
CI runs with `--warn-overwrite=yes` enabled, which flags when a method is redefined. In `test/variable_rate.jl`, the function `affect2!` was defined identically at lines 89 and 99 — first for a `ConstantRateJump` and then for a `VariableRateJump`. Renaming the second to `affect2b!` (consistent with the `rate2b` already used on line 98) resolves the warning without changing behavior since both functions had identical bodies.

## Test plan
- [x] Full `Pkg.test()` passes locally (all test groups)
- [x] No method overwrite warnings remain in test output
- [x] Runic formatting check passes
- [ ] CI InterfaceI jobs should no longer show the `affect2!` overwrite warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)