### PR TITLE
fix VR_Direct/FW type instability, reduce gene expr test variants

### DIFF
--- a/src/JumpProcesses.jl
+++ b/src/JumpProcesses.jl
@@ -23,6 +23,10 @@ import Base: size, getindex, setindex!, length, similar, show, merge!, merge
 
 # Import functions we extend from packages
 import DiffEqCallbacks: gauss_points, gauss_weights
+# Cache gauss quadrature data at module load to avoid type instability from
+# non-const gauss_points/gauss_weights globals in DiffEqCallbacks.
+const _GAUSS_POINTS = gauss_points[4]
+const _GAUSS_WEIGHTS = gauss_weights[4]
 import DiffEqBase: DiscreteCallback, init, solve, solve!, initialize!
 import SciMLBase: plot_indices
 import DataStructures: update!


### PR DESCRIPTION
Cache gauss_points/gauss_weights as module-level const to fix type instability from non-const globals in DiffEqCallbacks. Add loop-based cumsum_rates! for AbstractVector to avoid dynamic splatting in VR_DirectFW. Reduce gene expr test variants: test use_stepper=false and Float64 u0 with subset of algorithms, use init/reinit!/solve! pattern in runSSAs_ode.

Gene expr test: 543s → 125s (4.4×), 15.36G → 73M allocs (210×).
