### PR TITLE
Fix SciMLBase v3 breaking changes and bump version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JumpProcesses"
 uuid = "ccbc3e58-028d-4f4c-8cd5-9ae44345cda5"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "9.25.0"
+version = "9.26.0"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
@@ -53,7 +53,7 @@ Random = "1"
 RecursiveArrayTools = "3.35, 4"
 Reexport = "1.2"
 SafeTestsets = "0.1"
-SciMLBase = "2.115"
+SciMLBase = "2.115, 3"
 StableRNGs = "1"
 StaticArrays = "1.9.8"
 Statistics = "1"

--- a/src/SSA_stepper.jl
+++ b/src/SSA_stepper.jl
@@ -56,7 +56,7 @@ see the
 [tutorial](https://docs.sciml.ai/JumpProcesses/stable/tutorials/discrete_stochastic_example/)
 for details.
 """
-struct SSAStepper <: DiffEqBase.DEAlgorithm end
+struct SSAStepper <: DiffEqBase.AbstractDEAlgorithm end
 SciMLBase.allows_late_binding_tstops(::SSAStepper) = true
 
 """

--- a/src/simple_regular_solve.jl
+++ b/src/simple_regular_solve.jl
@@ -1,6 +1,6 @@
-struct SimpleTauLeaping <: DiffEqBase.DEAlgorithm end
+struct SimpleTauLeaping <: DiffEqBase.AbstractDEAlgorithm end
 
-struct SimpleExplicitTauLeaping{T <: AbstractFloat} <: DiffEqBase.DEAlgorithm
+struct SimpleExplicitTauLeaping{T <: AbstractFloat} <: DiffEqBase.AbstractDEAlgorithm
     epsilon::T  # Error control parameter
 end
 

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -1,5 +1,5 @@
 function DiffEqBase.__solve(jump_prob::DiffEqBase.AbstractJumpProblem{P},
-        alg::DiffEqBase.DEAlgorithm;
+        alg::DiffEqBase.AbstractDEAlgorithm;
         merge_callbacks = true, kwargs...) where {P}
     # Merge jump_prob.kwargs with passed kwargs
     kwargs = DiffEqBase.merge_problem_kwargs(jump_prob; merge_callbacks, kwargs...)
@@ -33,7 +33,7 @@ function DiffEqBase.__solve(jump_prob::DiffEqBase.AbstractJumpProblem; kwargs...
 end
 
 function DiffEqBase.__init(_jump_prob::DiffEqBase.AbstractJumpProblem{P},
-        alg::DiffEqBase.DEAlgorithm; merge_callbacks = true, kwargs...) where {P}
+        alg::DiffEqBase.AbstractDEAlgorithm; merge_callbacks = true, kwargs...) where {P}
     # Merge jump_prob.kwargs with passed kwargs
     kwargs = DiffEqBase.merge_problem_kwargs(_jump_prob; merge_callbacks, kwargs...)
 


### PR DESCRIPTION
## Summary
- Replace removed `DiffEqBase.DEAlgorithm` with `DiffEqBase.AbstractDEAlgorithm` in type definitions and function signatures
- Update SciMLBase compat bounds to include v3: `"2.115, 3"`
- Bump package version to 9.26.0
- Supersedes #576

## Changes

**`src/SSA_stepper.jl`**: `SSAStepper <: DiffEqBase.DEAlgorithm` → `<: DiffEqBase.AbstractDEAlgorithm`

**`src/simple_regular_solve.jl`**:
- `SimpleTauLeaping <: DiffEqBase.DEAlgorithm` → `<: DiffEqBase.AbstractDEAlgorithm`
- `SimpleExplicitTauLeaping <: DiffEqBase.DEAlgorithm` → `<: DiffEqBase.AbstractDEAlgorithm`

**`src/solve.jl`**:
- `DiffEqBase.__solve` signature: `alg::DiffEqBase.DEAlgorithm` → `alg::DiffEqBase.AbstractDEAlgorithm`
- `DiffEqBase.__init` signature: `alg::DiffEqBase.DEAlgorithm` → `alg::DiffEqBase.AbstractDEAlgorithm`

**`Project.toml`**: version `9.25.0` → `9.26.0`, SciMLBase compat `"2.115"` → `"2.115, 3"`

## Test plan
- [ ] CI passes with SciMLBase v2 (existing compat lower bound)
- [ ] CI passes with SciMLBase v3 (new upper bound)

🤖 Generated with [Claude Code](https://claude.com/claude-code)