### PR TITLE
Prepare source for SciMLBase v3 and widen compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JumpProcesses"
 uuid = "ccbc3e58-028d-4f4c-8cd5-9ae44345cda5"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "9.25.0"
+version = "9.25.1"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
@@ -53,7 +53,7 @@ Random = "1"
 RecursiveArrayTools = "3.35, 4"
 Reexport = "1.2"
 SafeTestsets = "0.1"
-SciMLBase = "2.115"
+SciMLBase = "2.115, 3.1"
 StableRNGs = "1"
 StaticArrays = "1.9.8"
 Statistics = "1"

--- a/src/SSA_stepper.jl
+++ b/src/SSA_stepper.jl
@@ -56,7 +56,7 @@ see the
 [tutorial](https://docs.sciml.ai/JumpProcesses/stable/tutorials/discrete_stochastic_example/)
 for details.
 """
-struct SSAStepper <: DiffEqBase.DEAlgorithm end
+struct SSAStepper <: DiffEqBase.AbstractDEAlgorithm end
 SciMLBase.allows_late_binding_tstops(::SSAStepper) = true
 
 """
@@ -115,6 +115,15 @@ end
 
 function DiffEqBase.u_modified!(integrator::SSAIntegrator, bool::Bool)
     integrator.u_modified = bool
+end
+
+# SciMLBase v3 renamed `u_modified!` to `derivative_discontinuity!` and internal
+# callback code now calls the new name. Define the method when available so
+# callbacks keep working on v3. Guarded so the file still loads on v2.
+@static if isdefined(SciMLBase, :derivative_discontinuity!)
+    function SciMLBase.derivative_discontinuity!(integrator::SSAIntegrator, bool::Bool)
+        integrator.u_modified = bool
+    end
 end
 
 function DiffEqBase.__solve(jump_prob::JumpProblem, alg::SSAStepper; kwargs...)

--- a/src/simple_regular_solve.jl
+++ b/src/simple_regular_solve.jl
@@ -1,6 +1,6 @@
-struct SimpleTauLeaping <: DiffEqBase.DEAlgorithm end
+struct SimpleTauLeaping <: DiffEqBase.AbstractDEAlgorithm end
 
-struct SimpleExplicitTauLeaping{T <: AbstractFloat} <: DiffEqBase.DEAlgorithm
+struct SimpleExplicitTauLeaping{T <: AbstractFloat} <: DiffEqBase.AbstractDEAlgorithm
     epsilon::T  # Error control parameter
 end
 

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -1,5 +1,5 @@
 function DiffEqBase.__solve(jump_prob::DiffEqBase.AbstractJumpProblem{P},
-        alg::DiffEqBase.DEAlgorithm;
+        alg::DiffEqBase.AbstractDEAlgorithm;
         merge_callbacks = true, kwargs...) where {P}
     # Merge jump_prob.kwargs with passed kwargs
     kwargs = DiffEqBase.merge_problem_kwargs(jump_prob; merge_callbacks, kwargs...)
@@ -33,7 +33,7 @@ function DiffEqBase.__solve(jump_prob::DiffEqBase.AbstractJumpProblem; kwargs...
 end
 
 function DiffEqBase.__init(_jump_prob::DiffEqBase.AbstractJumpProblem{P},
-        alg::DiffEqBase.DEAlgorithm; merge_callbacks = true, kwargs...) where {P}
+        alg::DiffEqBase.AbstractDEAlgorithm; merge_callbacks = true, kwargs...) where {P}
     # Merge jump_prob.kwargs with passed kwargs
     kwargs = DiffEqBase.merge_problem_kwargs(_jump_prob; merge_callbacks, kwargs...)
 


### PR DESCRIPTION
## Summary

Forward-compat groundwork for SciMLBase v3. Widens `SciMLBase` compat to `"2.115, 3"` and fixes the two v3-breaking API uses that live in JumpProcesses source:

- `DEAlgorithm` (type alias removed in SciMLBase v3) → `AbstractDEAlgorithm` on the `SSAStepper`, `SimpleTauLeaping`, `SimpleExplicitTauLeaping` structs and the two `DiffEqBase.__solve` / `DiffEqBase.__init` dispatches in `src/solve.jl`.
- `SciMLBase.derivative_discontinuity!(::SSAIntegrator, ::Bool)` method added alongside the existing `DiffEqBase.u_modified!` method. SciMLBase v3 renamed `u_modified!` to `derivative_discontinuity!` and the internal callback machinery now calls the new name, so SSAIntegrator needs a method for it. Guarded with `@static if isdefined(SciMLBase, :derivative_discontinuity!)` so this file still loads on v2 (which doesn't define the function).

## Relationship to #578

This does **not** make the dependabot PR #578 green on its own. The actual failure in #578's CI is:

```
caused by: empty intersection between SciMLBase@2.155.0 and project compatibility 3.1.0 - 3
```

That happens because:
1. Dependabot CI sets `force_latest_compatible_version=true`, which forces the resolver to pick from the upper compat range (SciMLBase v3).
2. `DiffEqBase.jl` master still pins `SciMLBase = "2.143.0"`, so no registered DiffEqBase version accepts SciMLBase v3, and resolution fails.

Until DiffEqBase.jl ships SciMLBase v3 support, #578 will keep failing regardless of what JumpProcesses' own compat says. This PR is the JumpProcesses-side piece of that migration and is safe to merge now since a regular (non-dependabot) PR resolves fine on v2.

## Known follow-ups (not in this PR, need v3 installable to test)

- `ext/JumpProcessesKernelAbstractionsExt.jl:49–61` passes `(sol, i)` to `ensembleprob.output_func`. SciMLBase v3 changed the signature to `(sol, ctx::EnsembleContext)`. Needs branching or a ctx construction once v3 is testable.
- Test files `test/thread_safety.jl:29` and `test/ensemble_uniqueness.jl:14` use the old `prob_func(prob, i, repeat)` signature; v3's EnsembleProblem calls `prob_func(prob, ctx)` directly.
- Internal `u_modified!` calls in `src/variable_rate.jl`, `src/aggregators/coevolve.jl`, `src/aggregators/ssajump.jl` will work on v3 via the deprecation shim but will emit depwarns; can be renamed to `derivative_discontinuity!` once v3 is the floor.

## Test plan

- [x] `Pkg.test()` passes locally on Julia 1.11 + SciMLBase 2.155.0 (all test sets, ~32 min).
- [ ] CI green on v2 (blocked on DiffEqBase v3 support to actually exercise v3 path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)