### PR TITLE
Patch v9.26.1: tighten OrdinaryDiffEqCore lower bound to 3.17

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JumpProcesses"
 uuid = "ccbc3e58-028d-4f4c-8cd5-9ae44345cda5"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "9.26.0"
+version = "9.26.1"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
@@ -46,7 +46,7 @@ KernelAbstractions = "0.9"
 LinearAlgebra = "1"
 LinearSolve = "3"
 OrdinaryDiffEq = "6"
-OrdinaryDiffEqCore = "3, 4"
+OrdinaryDiffEqCore = "3.17, 4"
 Pkg = "1"
 PoissonRandom = "0.4"
 Random = "1"


### PR DESCRIPTION
## Summary

Patch release fixing a downstream-breaking bug introduced in JumpProcesses v9.24.0.

`JumpProcessesOrdinaryDiffEqCoreExt` (added in v9.24.0, commit 31ca00b1) imports `StochasticDiffEqAlgorithm` and `StochasticDiffEqRODEAlgorithm` from `OrdinaryDiffEqCore`, but those abstract types were only added in **OrdinaryDiffEqCore v3.17.0**. The current compat `OrdinaryDiffEqCore = "3, 4"` lets the resolver pick anything from v3.0.x onward — including v3.0–v3.16 which don't define the symbols.

When a downstream package pins JumpProcesses ≥ v9.24 alongside an OrdinaryDiffEq-v6 / ModelingToolkit-v9 stack, `OrdinaryDiffEqCore` gets transitively downgraded to v3.1.x and the extension precompile dies:

```
WARNING: Imported binding OrdinaryDiffEqCore.StochasticDiffEqAlgorithm was undeclared at import time during import to JumpProcessesOrdinaryDiffEqCoreExt.
ERROR: LoadError: UndefVarError: ` + '`StochasticDiffEqAlgorithm`' + ` not defined in ` + '`JumpProcessesOrdinaryDiffEqCoreExt`' + `
```

Reproduced in the wild on:
- SciML/SBMLToolkit.jl#199 (Julia 1.10 LTS and Julia 1.12 — resolver downgrades `OrdinaryDiffEqCore` v3.33.1 → v3.1.0)
- SciML/SBMLToolkitTestSuite.jl#63 (resolves directly to v3.1.0)

## Changes

- Bump `version` to `9.26.1`
- Tighten `OrdinaryDiffEqCore` compat from `"3, 4"` to `"3.17, 4"` so the resolver can only pick versions that actually define the imported symbols.

## Companion PR

A retroactive registry fix is open at JuliaRegistries/General to apply the same compat tightening to already-released versions (v9.24.0, v9.25.0, v9.25.1, v9.26.0) so existing-version resolves stop pulling in the broken combination.

## Test plan

- [ ] CI passes (the precompile failure on `JumpProcessesOrdinaryDiffEqCoreExt` should disappear because the resolver can no longer pick v3.1.x).
- [ ] Downstream SBMLToolkit#199 / SBMLToolkitTestSuite#63 unblock once this lands and is registered.