### PR TITLE
fix: fix `integ.ps` syntax for `SSAStepper`

### DIFF
--- a/src/SSA_stepper.jl
+++ b/src/SSA_stepper.jl
@@ -122,6 +122,7 @@ end
 # struct field (which would be a breaking ABI change).
 @inline function Base.getproperty(integrator::SSAIntegrator, sym::Symbol)
     sym === :derivative_discontinuity && return getfield(integrator, :u_modified)
+    sym === :ps && return SII.ParameterIndexingProxy(integrator)
     return getfield(integrator, sym)
 end
 


### PR DESCRIPTION
#581 broke symbolic indexing, since `getproperty` used to fall back to the one defined in SciMLBase, which supports `integ.ps` for symbolic indexing. This PR re-adds this behavior.