### PR TITLE
Fix GPU CI: qualify validate_pure_leaping_inputs in KernelAbstractions ext

### DIFF
--- a/ext/JumpProcessesKernelAbstractionsExt.jl
+++ b/ext/JumpProcessesKernelAbstractionsExt.jl
@@ -23,7 +23,7 @@ function SciMLBase.__solve(ensembleprob::SciMLBase.AbstractEnsembleProblem,
     jump_prob = ensembleprob.prob
 
     # Validate that this is a PureLeaping JumpProblem
-    validate_pure_leaping_inputs(jump_prob, alg) ||
+    JumpProcesses.validate_pure_leaping_inputs(jump_prob, alg) ||
         error("SimpleTauLeaping can only be used with PureLeaping JumpProblems with only non-RegularJumps.")
     prob = jump_prob.prob
 


### PR DESCRIPTION
## Summary
- Master GPU CI is red with `UndefVarError: validate_pure_leaping_inputs not defined in JumpProcessesKernelAbstractionsExt` (last red run: SciML/JumpProcesses.jl actions run 25110242250).
- `validate_pure_leaping_inputs` is defined in `src/simple_regular_solve.jl` but not exported from `JumpProcesses`. The extension was calling it bare, which is invalid since `using JumpProcesses` only brings exported names into scope.
- Smallest possible fix: qualify the call with `JumpProcesses.validate_pure_leaping_inputs(...)`. Matches the existing pattern in `JumpProcessesOrdinaryDiffEqCoreExt.jl`, which uses `JumpProcesses.__jump_init`.

## Notes
- Please ignore until reviewed by @ChrisRackauckas.
- CPU `Run Tests` was already green; this only affects the `GPU Tests` workflow.
- GPU CI cannot be reproduced locally; the fix is verified by reading the failure log and matching it against the known-unexported function.

## Test plan
- [ ] GPU Tests workflow passes on this PR.
- [ ] CPU Run Tests still green (unchanged code path on CPU).

🤖 Generated with [Claude Code](https://claude.com/claude-code)