### PR TITLE
TEST ONLY: verify SciML/PoissonRandom.jl#72 unblocks GPU tau-leaping

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -81,3 +81,8 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 test = ["ADTypes", "Aqua", "ExplicitImports", "FastBroadcast", "LinearAlgebra", "LinearSolve", "OrdinaryDiffEq", "OrdinaryDiffEqFunctionMap", "Pkg", "SafeTestsets", "StableRNGs", "Statistics", "StochasticDiffEq", "Test"]
+
+# TEMPORARY: pin PoissonRandom to the fix branch from SciML/PoissonRandom.jl#72
+# until that PR merges + a 0.4.8 release lands in General. REMOVE BEFORE MERGE.
+[sources]
+PoissonRandom = {url = "https://github.com/ChrisRackauckas-Claude/PoissonRandom.jl.git", rev = "fix-passthroughrng-overlay-shadowing"}


### PR DESCRIPTION
**This PR exists solely to run GPU CI against the proposed fix in [SciML/PoissonRandom.jl#72](https://github.com/SciML/PoissonRandom.jl/pull/72) before that PR is released. Do not merge.**

## Background
Issue #588: GPU kernel compile fails with `InvalidIRError: jl_f_throw_methoderror` on Julia 1.12 / latest CUDACore.

Root cause is in PoissonRandom, not in JumpProcesses. GPUCompiler installs CUDACore's overrides into a Julia overlay method table via `Base.Experimental.@consistent_overlay`. Julia 1.12's `OverlayMethodTable.findall` returns overlay matches without consulting the base method table whenever the overlay fully covers the signature (Compiler/src/methodtable.jl:73–92). So `@device_override Random.randexp(rng::AbstractRNG)` shadows PoissonRandom's specific `Random.randexp(rng::PassthroughRNG)` on the device, and the override body runs with `rng::PassthroughRNG`. Its `Random.rand(rng, UInt52Raw())` then reaches `rng_native_52(::PassthroughRNG)` which has no method — hence the static `throw(MethodError)` that GPUCompiler rejects.

[SciML/PoissonRandom.jl#72](https://github.com/SciML/PoissonRandom.jl/pull/72) fixes this by adding the two forwarding methods PassthroughRNG needs to survive overlay shadowing:

```julia
Random.rng_native_52(::PassthroughRNG) = UInt64
Random.rand(rng::PassthroughRNG, ::Type{T}) where {T} = rand(T)
```

## This PR
- No code change to JumpProcesses.
- Adds a `[sources]` override in `Project.toml` pinning PoissonRandom to the fix branch.
- Purpose: prove on real GPU CI that the PoissonRandom fix unblocks `test/gpu/regular_jumps.jl`.

## Plan after CI
- If GPU Tests **pass**: merge SciML/PoissonRandom.jl#72, tag 0.4.8, **close this PR without merging**. JumpProcesses master will then pick up 0.4.8 automatically (existing compat is `"0.4"`).
- If GPU Tests **fail**: the failure narrows the remaining problem; iterate on PoissonRandom or follow up upstream (there is a known separate CUDA.jl bug — `@noinline randexp_unlikely` triggers `julia.get_pgcstack` on Julia 1.12 — that may surface once the MethodError is unblocked).

## Notes
- Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)