### PR TITLE
Fix docs build: explicit JumpProcesses/StochasticDiffEq imports after DiffEq 8.0

### DIFF
--- a/docs/src/tutorials/discrete_stochastic_example.md
+++ b/docs/src/tutorials/discrete_stochastic_example.md
@@ -42,15 +42,15 @@ Catalyst, which should ensure optimal jump types are selected to represent each
 reaction, and necessary data structures for the simulation algorithms, such as
 dependency graphs, are automatically calculated.
 
-We'll make use of the
-[DifferentialEquations.jl](https://docs.sciml.ai/DiffEqDocs/stable/)
-meta package, which includes JumpProcesses and ODE/SDE solvers, Plots.jl, and
-(optionally) Catalyst.jl in this tutorial. If not already installed, they can be
-added as follows:
+We'll make use of [JumpProcesses.jl](https://docs.sciml.ai/JumpProcesses/stable/)
+together with [OrdinaryDiffEq.jl](https://docs.sciml.ai/OrdinaryDiffEq/stable/)
+(for ODE solvers), Plots.jl, and (optionally) Catalyst.jl in this tutorial. If
+not already installed, they can be added as follows:
 
 ```julia
 using Pkg
-Pkg.add("DifferentialEquations")
+Pkg.add("JumpProcesses")
+Pkg.add("OrdinaryDiffEq")
 Pkg.add("Plots")
 Pkg.add("Catalyst")                # optional
 ```
@@ -58,12 +58,12 @@ Pkg.add("Catalyst")                # optional
 Let's now load the required packages and set some default plot settings
 
 ```julia
-using DifferentialEquations, Plots, LinearAlgebra
+using JumpProcesses, OrdinaryDiffEq, Plots, LinearAlgebra
 default(; lw = 2)
 ```
 
 ```@setup tut2
-using DifferentialEquations, Plots, LinearAlgebra
+using JumpProcesses, OrdinaryDiffEq, Plots, LinearAlgebra
 default(; lw = 2)
 ```
 

--- a/docs/src/tutorials/jump_diffusion.md
+++ b/docs/src/tutorials/jump_diffusion.md
@@ -30,17 +30,16 @@ not already installed
 
 ```julia
 using Pkg
-Pkg.add("DifferentialEquations")
+Pkg.add("JumpProcesses")
+Pkg.add("OrdinaryDiffEq")
+Pkg.add("StochasticDiffEq")
 Pkg.add("Plots")
 ```
-
-DifferentialEquations.jl will install JumpProcesses, along with the needed ODE and
-SDE solvers.
 
 We then load these packages, and set some plotting defaults, as
 
 ```@example tut3
-using DifferentialEquations, Plots
+using JumpProcesses, StochasticDiffEq, OrdinaryDiffEq, Plots
 default(; lw = 2)
 ```
 


### PR DESCRIPTION
> Please ignore until reviewed by @ChrisRackauckas.

## Summary

The Documentation workflow has been failing on `master` since 2026-05-11 (PR #591, the dependabot `DifferentialEquations 7.11 -> 8.0` bump in `docs/Project.toml`).

`DifferentialEquations.jl` v8.0.0 only reexports `SciMLBase` and `OrdinaryDiffEq`. It no longer reexports `JumpProcesses`, `StochasticDiffEq`, `DiffEqNoiseProcess`, `DiffEqCallbacks`, etc. As a result, `using DifferentialEquations` in the tutorials no longer brings symbols like `JumpProblem`, `ConstantRateJump`, `VariableRateJump`, `Direct`, `SSAStepper`, or `SRIW1` into scope, and the Documenter build fails with:

```
UndefVarError: `JumpProblem` not defined in `Main.__atexample__named__tut3`
@ docs/src/tutorials/jump_diffusion.md:163
```

The "also exported by ModelingToolkitBase / Catalyst" hints in Documenter's output are red herrings emitted because those packages are loaded elsewhere in the build — they do not actually shadow `JumpProcesses.JumpProblem`. The root cause is the lost reexport in DifferentialEquations 8.0.

## Fix

Replace `using DifferentialEquations` with explicit imports in the two affected tutorial files:

- `docs/src/tutorials/jump_diffusion.md` (`tut3`): `using JumpProcesses, StochasticDiffEq, OrdinaryDiffEq, Plots`
- `docs/src/tutorials/discrete_stochastic_example.md` (`tut2` `@example` and `@setup` blocks): `using JumpProcesses, OrdinaryDiffEq, Plots, LinearAlgebra`

Updated the corresponding `Pkg.add` prose to match. `docs/src/tutorials/simple_poisson_process.md` already uses explicit `using JumpProcesses, Plots` and was not affected.

## Verification

Reproduced the failure locally against the current `docs/Project.toml` (DifferentialEquations 8.0.0, Catalyst 16.1.1, ModelingToolkitBase 1.35.0) on Julia 1.11:

```
julia> using DifferentialEquations
julia> isdefined(@__MODULE__, :JumpProblem)
false
julia> isdefined(@__MODULE__, :ConstantRateJump)
false
julia> isdefined(@__MODULE__, :SRIW1)
false
```

After the fix, ran the full code from both tutorials end-to-end with `using JumpProcesses, StochasticDiffEq, OrdinaryDiffEq, Plots` (for `tut3`) and `using JumpProcesses, OrdinaryDiffEq, Plots, LinearAlgebra` + `using Catalyst` (for `tut2`): both complete successfully.

## Test plan

- [ ] CI's "Documentation" workflow goes green on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)