### PR TITLE
Fix shared-RNG data race in saveat_regression ensemble test

### DIFF
--- a/test/saveat_regression.jl
+++ b/test/saveat_regression.jl
@@ -1,6 +1,5 @@
 using DiffEqBase, JumpProcesses, Test
 using StableRNGs
-rng = StableRNG(12345)
 
 rate_consts = [10.0]
 reactant_stoich = [[1 => 1, 2 => 1]]
@@ -10,12 +9,26 @@ maj = MassActionJump(rate_consts, reactant_stoich, net_stoich)
 n0 = [1, 1, 0]
 tspan = (0, 0.2)
 dprob = DiscreteProblem(n0, tspan)
-jprob = JumpProblem(dprob, Direct(), maj, save_positions = (false, false), rng = rng)
 ts = collect(0:0.002:tspan[2])
-NA = zeros(length(ts))
 Nsims = 10_000
-sol = JumpProcesses.solve(EnsembleProblem(jprob), SSAStepper(), saveat = ts,
-    trajectories = Nsims)
+
+# Give every trajectory its own independent, seeded RNG. EnsembleProblems default to
+# EnsembleThreads(), so sharing one mutable RNG across trajectories is a data race that
+# corrupts the RNG state. A fresh StableRNG per trajectory keeps the solve race-free and
+# reproducible.
+function jprob_func(save_positions)
+    function (prob, ctx)
+        rng = StableRNG(12345 + ctx.sim_id)
+        JumpProblem(dprob, Direct(), maj; save_positions, rng)
+    end
+end
+
+jprob = JumpProblem(dprob, Direct(), maj, save_positions = (false, false),
+    rng = StableRNG(12345))
+NA = zeros(length(ts))
+sol = JumpProcesses.solve(
+    EnsembleProblem(jprob; prob_func = jprob_func((false, false))), SSAStepper(),
+    saveat = ts, trajectories = Nsims)
 
 for i in 1:length(sol.u)
     NA .+= sol.u[i][1, :]
@@ -26,10 +39,12 @@ for i in 1:length(ts)
 end
 
 NA = zeros(length(ts))
-jprob = JumpProblem(dprob, Direct(), maj; rng = rng)
+jprob = JumpProblem(dprob, Direct(), maj; rng = StableRNG(12345))
 sol = nothing;
 GC.gc();
-sol = JumpProcesses.solve(EnsembleProblem(jprob), SSAStepper(), trajectories = Nsims)
+sol = JumpProcesses.solve(
+    EnsembleProblem(jprob; prob_func = jprob_func((false, true))), SSAStepper(),
+    trajectories = Nsims)
 
 for i in 1:Nsims
     for n in 1:length(ts)


### PR DESCRIPTION
**Ignore until reviewed by @ChrisRackauckas.**

## Problem

`test/saveat_regression.jl` shares a single `StableRNG(12345)` across every trajectory of an `EnsembleProblem` solved with the default `EnsembleThreads()`. Under multithreading (`JULIA_NUM_THREADS=auto`/`8`), worker threads concurrently mutate the one `LehmerRNG`, racing on its internal state. The corruption produces degenerate trajectories, the ensemble mean no longer tracks `exp(-10t)`, and roughly 190/202 of the `rtol=0.1` assertions fail nondeterministically. This is a flaky failure observed on `master`'s own `Tests (lts/pre, InterfaceII)` jobs. Single-threaded the test passes 202/202.

## Fix

Give every trajectory its own independent, seeded `StableRNG` via the `EnsembleProblem` `prob_func`, keyed off `ctx.sim_id`. This makes the threaded solve race-free and reproducible.

- Does **not** switch to `EnsembleSerial()` — the threaded path is still exercised.
- Does **not** loosen the `rtol` — it remains a real `rtol=0.1` regression check.
- Preserves the original per-solve `save_positions` (`(false, false)` for the saveat solve, the `DiscreteProblem` default `(false, true)` for the interpolated solve), so the statistical intent is unchanged.

Only `test/saveat_regression.jl` is touched. File is already SciMLStyle-formatted (JuliaFormatter v2, no diff).

## Verification (run locally, multithreaded, latest deps)

Isolated depot, JumpProcesses 9.29.0 / DiffEqBase 7.5.5 / SciMLBase 3.18.0 / StableRNGs 1.0.4.

Before (unmodified `master`):
```
# Julia 1.10, JULIA_NUM_THREADS=8 (3 runs) and Julia 1.11, 8 threads
saveat_regression (wrapped) |   12   190    202   # FAIL, every run
# single-threaded: 202 202  (passes)
```

After (this PR):
```
# Julia 1.10, 8 threads x4:   202 202
# Julia 1.10, auto/128 threads: 202 202
# Julia 1.11, 8 threads x3:   202 202
```
Passes deterministically across all repeated multithreaded runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)