### PR TITLE
Remove allow-reresolve input from central downgrade caller

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -18,5 +18,4 @@ jobs:
     with:
       julia-version: "1.10"
       skip: "Pkg,TOML"
-      allow-reresolve: false
     secrets: "inherit"


### PR DESCRIPTION
## Summary

The `allow-reresolve` input is no longer accepted by the centralized `SciML/.github` reusable downgrade workflow (`downgrade.yml`). This PR removes the now-obsolete `allow-reresolve: false` line from the `with:` block of the central caller in `.github/workflows/Downgrade.yml`.

This is a minimal cleanup that was missed by the earlier sweep removing this input across SciML repos.

## Scope

- Removes ONLY the `allow-reresolve:` line passed to the `uses: SciML/.github/.github/workflows/downgrade.yml@v1` caller.
- Does NOT touch any inline `julia-downgrade-compat` action steps (none exist in this file anyway); those keep their own `allow_reresolve` meaning where applicable.

## Note

**Ignore until reviewed by @ChrisRackauckas.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)