### PR TITLE
Canonical CI: grouped-tests.yml + root test/test_groups.toml

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -18,23 +18,5 @@ concurrency:
 
 jobs:
   tests:
-    name: "Tests"
-    strategy:
-      fail-fast: false
-      matrix:
-        version:
-          - "1"
-          - "lts"
-          - "pre"
-        group:
-          - InterfaceI
-          - InterfaceII
-          - QA
-        exclude:
-          - version: "pre"
-            group: QA
-    uses: "SciML/.github/.github/workflows/tests.yml@v1"
-    with:
-      julia-version: "${{ matrix.version }}"
-      group: ${{ matrix.group }}
+    uses: "SciML/.github/.github/workflows/grouped-tests.yml@v1"
     secrets: "inherit"

--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -1,0 +1,8 @@
+[InterfaceI]
+versions = ["lts", "1", "pre"]
+
+[InterfaceII]
+versions = ["lts", "1", "pre"]
+
+[QA]
+versions = ["lts", "1"]


### PR DESCRIPTION
## Summary

Converts the root test workflow (`Tests.yml`) into the canonical thin caller of `SciML/.github/.github/workflows/grouped-tests.yml@v1`, moving the test matrix into a new root `test/test_groups.toml`.

### What changed
- **`.github/workflows/Tests.yml`**: the hand-maintained `version × group` matrix job (which called `tests.yml@v1`) is replaced by a thin caller:
  ```yaml
  jobs:
    tests:
      uses: "SciML/.github/.github/workflows/grouped-tests.yml@v1"
      secrets: "inherit"
  ```
  `name: "Run Tests"`, the `on:` triggers (push/PR to `master`, `paths-ignore: docs/**`), and the `concurrency:` block are all preserved verbatim, so branch-protection status checks are unaffected.
- **`test/test_groups.toml`** (new, repo root): declares the matrix once.
  ```toml
  [InterfaceI]
  versions = ["lts", "1", "pre"]

  [InterfaceII]
  versions = ["lts", "1", "pre"]

  [QA]
  versions = ["lts", "1"]
  ```

No `with:` inputs are needed: `runtests.jl` already reads the standard `GROUP` env var, and `check-bounds` (`yes`), `coverage` (`true`), `coverage-directories` (`src,ext` — this package has extensions) and `group-env-name` (`GROUP`) all match the `grouped-tests.yml@v1` defaults that the old job was already using. Linux-only, so no `os` field is added (default `ubuntu-latest`). No `runtests.jl` change — the `QA`/`InterfaceI`/`InterfaceII` GROUP dispatch already exists.

### Matrix match
Verified with `compute_affected_sublibraries.jl <root> --root-matrix` (SciML/.github@v1). The emitted `(group, version)` set is **8/8 exact** vs. the old workflow:

| group | versions |
|-------|----------|
| InterfaceI | lts, 1, pre |
| InterfaceII | lts, 1, pre |
| QA | lts, 1 |

Old matrix was `{1, lts, pre} × {InterfaceI, InterfaceII, QA}` excluding `pre + QA` = 8 cells; the new TOML reproduces exactly those 8 cells. TOML and YAML both parse cleanly.

### QA
Category A (QA group already present in `runtests.jl`), so static matrix-verify only; no local Aqua/JET run performed and no source changes. No QA exclusions were added.

All other workflow files (Downgrade, Documentation, FormatCheck, GPU, SpellCheck, TagBot, DependabotAutoMerge, DocPreviewCleanup) are left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Ignore until reviewed by @ChrisRackauckas.