### PR TITLE
Fix deprecation

### DIFF
--- a/src/JumpProcesses.jl
+++ b/src/JumpProcesses.jl
@@ -39,7 +39,7 @@ using DiffEqBase: DiffEqBase, CallbackSet, ContinuousCallback, DAEFunction,
                   DDEFunction, DiscreteProblem, ODEFunction, ODEProblem,
                   ODESolution, ReturnCode, SDEFunction, SDEProblem, add_tstop!,
                   deleteat!, isinplace, remake, savevalues!, step!,
-                  u_modified!
+                  derivative_discontinuity!
 using SciMLBase: SciMLBase, DEIntegrator
 
 abstract type AbstractJump end

--- a/src/SSA_stepper.jl
+++ b/src/SSA_stepper.jl
@@ -136,17 +136,8 @@ function Base.propertynames(integrator::SSAIntegrator, private::Bool = false)
     return (fieldnames(SSAIntegrator)..., :derivative_discontinuity)
 end
 
-function DiffEqBase.u_modified!(integrator::SSAIntegrator, bool::Bool)
+function SciMLBase.derivative_discontinuity!(integrator::SSAIntegrator, bool::Bool)
     integrator.u_modified = bool
-end
-
-# SciMLBase v3 renamed `u_modified!` to `derivative_discontinuity!` and internal
-# callback code now calls the new name. Define the method when available so
-# callbacks keep working on v3. Guarded so the file still loads on v2.
-@static if isdefined(SciMLBase, :derivative_discontinuity!)
-    function SciMLBase.derivative_discontinuity!(integrator::SSAIntegrator, bool::Bool)
-        integrator.u_modified = bool
-    end
 end
 
 function SciMLBase.__solve(jump_prob::JumpProblem, alg::SSAStepper; kwargs...)

--- a/src/aggregators/coevolve.jl
+++ b/src/aggregators/coevolve.jl
@@ -220,7 +220,7 @@ function accept_next_jump!(p::CoevolveJumpAggregation, integrator, u, params, t)
     p.prev_jump = next_jump
     generate_jumps!(p, integrator, integrator.u, integrator.p, integrator.t)
     register_next_jump_time!(integrator, p, integrator.t)
-    u_modified!(integrator, false)
+    derivative_discontinuity!(integrator, false)
 
     return false
 end

--- a/src/aggregators/ssajump.jl
+++ b/src/aggregators/ssajump.jl
@@ -65,7 +65,7 @@ function (p::AbstractSSAJumpAggregator)(dj, u, t, integrator) # initialize
     concretize_affects!(p, integrator)
     initialize!(p, integrator, u, integrator.p, t)
     register_next_jump_time!(integrator, p, integrator.t)
-    u_modified!(integrator, false)
+    derivative_discontinuity!(integrator, false)
     nothing
 end
 

--- a/src/variable_rate.jl
+++ b/src/variable_rate.jl
@@ -211,7 +211,7 @@ end
 # initialize: (cb, u, t, integrator)
 function (c::VR_FRMEventCallback)(cb, u, t, integrator)
     integrator.u.jump_u[c.idx] = -randexp(c.rng, typeof(integrator.t))
-    u_modified!(integrator, true)
+    derivative_discontinuity!(integrator, true)
     nothing
 end
 
@@ -372,7 +372,7 @@ end
 function initialize_vr_direct_wrapper(cb::ContinuousCallback, u, t, integrator)
     concretize_vr_direct_affects!(cb.condition, integrator)
     initialize_vr_direct_cache!(cb.condition, u, t, integrator)
-    u_modified!(integrator, false)
+    derivative_discontinuity!(integrator, false)
     nothing
 end
 

--- a/test/variable_rate.jl
+++ b/test/variable_rate.jl
@@ -611,7 +611,7 @@ let
     function switch_affect!(integ)
         integ.u[1] = max(round(integ.u[1]), 0.0)
         integ.p.mode = :SSA
-        u_modified!(integ, true)
+        derivative_discontinuity!(integ, true)
         reset_aggregated_jumps!(integ)
     end
     switch_cb = ContinuousCallback(switch_cond, switch_affect!)


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

This replaces the deprecated `u_modified!` with `derivative_discontinuity!`, as discussed #613
