### PR TITLE
Release prep: bump version to 9.29.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JumpProcesses"
 uuid = "ccbc3e58-028d-4f4c-8cd5-9ae44345cda5"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "9.29.1"
+version = "9.29.2"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"


### PR DESCRIPTION
## Summary

Bumps the `version` field in Project.toml from 9.29.1 to 9.29.2 (PATCH) to register the commits that have accumulated since the last release (v9.29.1, commit 0d01f00).

## Changes since v9.29.1

- Added public API docstrings to previously-undocumented exported/internal functions and structs (`PureLeaping`, `needs_depgraph`, `needs_vartojumps_map`, `BracketData`, `get_num_majumps`, `SimpleTauLeaping`, `SimpleExplicitTauLeaping`, `EnsembleGPUKernel`, `SpatialMassActionJump`, `num_sites`, `outdegree`, `CartesianGrid`, `CartesianGridRej`, `VR_DirectFW`) — #615 "Document JumpProcesses public API".
- Updated `test/qa.jl` to enable `SciMLTesting`'s `api_docs_kwargs` rendered-docs QA check, with a `REEXPORTED_API` ignore-list for names re-exported from other packages.
- Bumped the `SciMLTesting` compat lower bound from `1.6` to `2.1` (test-only dependency, listed only in `[extras]`/`[targets]`, not `[deps]`) — required for the `api_docs_kwargs` QA feature used above.

No source-level behavior changed: every diff in `src/` is a docstring addition to an existing function/struct with no logic changes. No new exported symbols were added, and no changes were made to compat bounds on any runtime SciML-ecosystem dependency (SciMLBase, DiffEqBase, etc.).

## Why PATCH

This is a docs/tests/QA-only change with no new functionality and no behavioral change, so per SemVer conventions this is a PATCH bump (9.29.1 -> 9.29.2).