### PR TITLE
TagBot: restore the registry trigger's detection marker

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,3 +1,7 @@
+# The General registry's TagBot trigger service decides whether TagBot is
+# installed by grepping this repo's workflow files for "JuliaRegistries/TagBot".
+# The thin caller below never mentions it, so this line must stay or registrations
+# stop being tagged. Removable once RegistryCI's filename-based check is deployed.
 name: "TagBot"
 on:
   issue_comment:


### PR DESCRIPTION
Demo of the one-line change proposed for https://github.com/SciML/JumpProcesses.jl/issues/618. **Ignore until reviewed by @ChrisRackauckas.**

The General registry's TagBot trigger job runs `RegistryCI.TagBot`, pinned to RegistryCI v10.10.4 in General's `.ci` Manifest. That version decides whether TagBot is installed on a repo by grepping the repo's own workflow files for the literal string `JuliaRegistries/TagBot`. The thin caller adopted in #603 does not contain it, so since 2026-06-08 the trigger has logged `TagBot is not enabled on SciML/JumpProcesses.jl` and never posted the comment that runs TagBot — hence v9.29.1 and v9.29.2 are registered but untagged.

https://github.com/JuliaRegistries/RegistryCI.jl/pull/724 fixes the detection by matching on filename, but it landed in the `AutoMerge/` subpackage, is unreleased, and General still uses `RegistryCI.TagBot` at 10.10.4 (RegistryCI 11 removed that module). So the marker is needed until that chain ships.

Verified against both versions of the detection function run over the real GitHub API:

```
before (master):        v10.10.4 -> nothing                              (not detected)
                        RegistryCI master -> .github/workflows/TagBot.yml
after (this branch):    v10.10.4 -> .github/workflows/TagBot.yml         (detected)
                        RegistryCI master -> .github/workflows/TagBot.yml
```

Tagging the already-registered v9.29.1/v9.29.2 still needs a `workflow_dispatch` run of TagBot after this merges; TagBot backfills every registered-but-untagged version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WGRSWoRMPcWrJYiaZpajtq