### PR TITLE
Use Base deleteat! directly

### DIFF
--- a/src/JumpProcesses.jl
+++ b/src/JumpProcesses.jl
@@ -38,7 +38,7 @@ import SymbolicIndexingInterface as SII
 using DiffEqBase: DiffEqBase, CallbackSet, ContinuousCallback, DAEFunction,
                   DDEFunction, DiscreteProblem, ODEFunction, ODEProblem,
                   ODESolution, ReturnCode, SDEFunction, SDEProblem, add_tstop!,
-                  deleteat!, isinplace, remake, savevalues!, step!,
+                  isinplace, remake, savevalues!, step!,
                   derivative_discontinuity!
 using SciMLBase: SciMLBase, DEIntegrator
 


### PR DESCRIPTION
> [!IMPORTANT]
> Please ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed

Remove `deleteat!` from the explicit DiffEqBase import list and use Base's binding directly.

`deleteat!` is exported by Base and used by `src/coupling.jl`. The stale non-owner import was added in https://github.com/SciML/JumpProcesses.jl/commit/033d48aed051fe2c95b91680b26aceeb5f0541ff and became visible to the current QA graph after https://github.com/SciML/JumpProcesses.jl/pull/624 allowed LinearSolve 5. ExplicitImports now correctly reports that Base owns the imported function.

This does not change runtime behavior or public API: unqualified `deleteat!` resolves to the same Base function without the redundant DiffEqBase import.

## Failing before

On current master `93d9c903689feaaec222b3708c627b0248abfd60`, Julia 1.10.11, and a fresh registered graph (LinearSolve 5.9.0, OrdinaryDiffEq 7.3.0, SciMLBase 3.44.0; no local package overrides):

```console
$ GROUP=QA /home/crackauc/.juliaup/bin/julia +1.10 --startup-file=no --project -e 'using Pkg; Pkg.test()'
ExplicitImportsFromNonOwnerException
Module `JumpProcesses` has explicit imports of names from modules other than their owner as determined via `Base.which`:
- `deleteat!` has owner `Base` but it was imported from `DiffEqBase` at `src/JumpProcesses.jl:41:19`

Test Summary:       | Pass  Fail  Error  Total
ExplicitImports     |    3            1      4
```

The same run also reports the independent intentional-reexport failure fixed by https://github.com/SciML/JumpProcesses.jl/pull/623.

## Passing after

After this one-line import correction, the same LinearSolve 5 graph reports:

```console
Test Summary:       | Pass  Total
ExplicitImports     |    4      4
```

Applying the independent one-line reexport fix from https://github.com/SciML/JumpProcesses.jl/pull/623 in the local validation checkout makes the entire QA group green:

```console
Test Summary: | Pass  Total   Time
QA Tests      |   15     15  31.1s
31.345975 seconds (25.07 M allocations: 1.352 GiB, 6.72% gc time, 72.55% compilation time: <1% of which was recompilation)
     Testing JumpProcesses tests passed
```

Additional checks:

```console
$ typos src/JumpProcesses.jl
# exit 0

$ git diff --check
# exit 0
```

The runtime group containing the affected split-coupling code also passes:

```console
$ GROUP=InterfaceI /home/crackauc/.juliaup/bin/julia +1.10 --startup-file=no --project -e 'using Pkg; Pkg.test()'
Test Summary:       | Pass  Total   Time
Split Coupled Tests |    5      5  37.7s
...
1285.631678 seconds (1.49 G allocations: 75.855 GiB, 2.93% gc time, 45.17% compilation time: <1% of which was recompilation)
     Testing JumpProcesses tests passed
```

The group completed with 860 passing assertions across 19 counted testsets. I did not run GPU, docs, prerelease, or downstream groups locally.

The repository-wide JuliaFormatter check is independently not clean on unmodified master and would rewrite 34 files, including reversals of intentional readability edits. That baseline failure is documented at https://github.com/SciML/JumpProcesses.jl/issues/458#issuecomment-5251192868; no mechanical formatting changes are included here.
