### PR TITLE
Preserve specialization in extended jump problems

### DIFF
--- a/src/variable_rate.jl
+++ b/src/variable_rate.jl
@@ -98,7 +98,7 @@ function extend_problem(prob::SciMLBase.AbstractODEProblem, jumps; rng = DEFAULT
     end
 
     u0 = extend_u0(prob, length(jumps), rng)
-    specialize = SciMLBase.specialization(typeof(prob.f))
+    specialize = SciMLBase.specialization(prob.f)
     f = ODEFunction{isinplace(prob), specialize}(jump_f; sys = prob.f.sys,
         observed = prob.f.observed)
     remake(prob; f, u0)
@@ -135,7 +135,7 @@ function extend_problem(prob::SciMLBase.AbstractSDEProblem, jumps; rng = DEFAULT
     end
 
     u0 = extend_u0(prob, length(jumps), rng)
-    specialize = SciMLBase.specialization(typeof(prob.f))
+    specialize = SciMLBase.specialization(prob.f)
     f = SDEFunction{isinplace(prob), specialize}(jump_f, jump_g; sys = prob.f.sys,
         observed = prob.f.observed)
     remake(prob; f, g = jump_g, u0)
@@ -162,7 +162,7 @@ function extend_problem(prob::SciMLBase.AbstractDDEProblem, jumps; rng = DEFAULT
     end
 
     u0 = extend_u0(prob, length(jumps), rng)
-    specialize = SciMLBase.specialization(typeof(prob.f))
+    specialize = SciMLBase.specialization(prob.f)
     f = DDEFunction{isinplace(prob), specialize}(jump_f; sys = prob.f.sys,
         observed = prob.f.observed)
     remake(prob; f, u0)
@@ -190,8 +190,7 @@ function extend_problem(prob::SciMLBase.AbstractDAEProblem, jumps; rng = DEFAULT
     end
 
     u0 = extend_u0(prob, length(jumps), rng)
-    specialize = SciMLBase.specialization(typeof(prob.f))
-    f = DAEFunction{isinplace(prob), specialize}(jump_f, sys = prob.f.sys,
+    f = DAEFunction{isinplace(prob)}(jump_f, sys = prob.f.sys,
         observed = prob.f.observed)
     remake(prob; f, u0)
 end

--- a/src/variable_rate.jl
+++ b/src/variable_rate.jl
@@ -98,7 +98,8 @@ function extend_problem(prob::SciMLBase.AbstractODEProblem, jumps; rng = DEFAULT
     end
 
     u0 = extend_u0(prob, length(jumps), rng)
-    f = ODEFunction{isinplace(prob)}(jump_f; sys = prob.f.sys,
+    specialize = SciMLBase.specialization(typeof(prob.f))
+    f = ODEFunction{isinplace(prob), specialize}(jump_f; sys = prob.f.sys,
         observed = prob.f.observed)
     remake(prob; f, u0)
 end
@@ -134,7 +135,8 @@ function extend_problem(prob::SciMLBase.AbstractSDEProblem, jumps; rng = DEFAULT
     end
 
     u0 = extend_u0(prob, length(jumps), rng)
-    f = SDEFunction{isinplace(prob)}(jump_f, jump_g; sys = prob.f.sys,
+    specialize = SciMLBase.specialization(typeof(prob.f))
+    f = SDEFunction{isinplace(prob), specialize}(jump_f, jump_g; sys = prob.f.sys,
         observed = prob.f.observed)
     remake(prob; f, g = jump_g, u0)
 end
@@ -160,7 +162,8 @@ function extend_problem(prob::SciMLBase.AbstractDDEProblem, jumps; rng = DEFAULT
     end
 
     u0 = extend_u0(prob, length(jumps), rng)
-    f = DDEFunction{isinplace(prob)}(jump_f; sys = prob.f.sys,
+    specialize = SciMLBase.specialization(typeof(prob.f))
+    f = DDEFunction{isinplace(prob), specialize}(jump_f; sys = prob.f.sys,
         observed = prob.f.observed)
     remake(prob; f, u0)
 end
@@ -187,7 +190,8 @@ function extend_problem(prob::SciMLBase.AbstractDAEProblem, jumps; rng = DEFAULT
     end
 
     u0 = extend_u0(prob, length(jumps), rng)
-    f = DAEFunction{isinplace(prob)}(jump_f, sys = prob.f.sys,
+    specialize = SciMLBase.specialization(typeof(prob.f))
+    f = DAEFunction{isinplace(prob), specialize}(jump_f, sys = prob.f.sys,
         observed = prob.f.observed)
     remake(prob; f, u0)
 end

--- a/test/extended_jump_array.jl
+++ b/test/extended_jump_array.jl
@@ -84,6 +84,40 @@ jump_prob = JumpProblem(oop_prob, Direct(), oop_test_jump)
 sol = solve(jump_prob, Tsit5())
 @test sol.retcode == ReturnCode.Success
 
+@testset "Extended problems preserve specialization" begin
+    rate(u, p, t) = one(t)
+    affect!(integrator) = nothing
+    jump = VariableRateJump(rate, affect!)
+
+    function f!(du, u, p, t)
+        du .= u
+        return nothing
+    end
+    function g!(du, u, p, t)
+        du .= 0.1
+        return nothing
+    end
+    function f_dde!(du, u, h, p, t)
+        du .= h(p, t - 1)
+        return nothing
+    end
+
+    ode_f = ODEFunction{true, AutoDespecialize}(f!)
+    sde_f = SDEFunction{true, AutoDespecialize}(f!, g!)
+    dde_f = DDEFunction{true, AutoDespecialize}(f_dde!)
+    problems = (
+        ODEProblem(ode_f, [1.0], (0.0, 1.0), [1.0]),
+        SDEProblem(sde_f, [1.0], (0.0, 1.0), [1.0]),
+        DDEProblem(dde_f, [1.0], (p, t) -> [1.0], (0.0, 1.0), [1.0];
+            constant_lags = [1.0])
+    )
+
+    for prob in problems
+        jump_prob = JumpProblem(prob, Direct(), jump; vr_aggregator = VR_FRM())
+        @test SciMLBase.specialization(typeof(jump_prob.prob.f)) == AutoDespecialize
+    end
+end
+
 # Test saveat https://github.com/SciML/JumpProcesses.jl/issues/179 and https://github.com/SciML/JumpProcesses.jl/issues/322
 let
     f(du, u, p, t) = (du[1] = u[1]; nothing)


### PR DESCRIPTION
## What changed

Variable-rate jump augmentation now preserves the source `ODEFunction`, `SDEFunction`, or `DDEFunction` specialization policy instead of reconstructing every function with the default `AutoSpecialize`. This lets ModelingToolkit `AutoDespecialize` remain active through `JumpProblem` and stabilizes the solver-facing problem/function types when only the concrete parameter representation changes.

The implementation uses the public, backward-compatible instance API `SciMLBase.specialization(prob.f)`, so this does not raise JumpProcesses SciMLBase compat. DAE augmentation is intentionally excluded: clean master has an independent broken DAE extension path, and its separate functional repair will preserve specialization with its own discriminating test.

Ignore this draft until reviewed by @ChrisRackauckas.

## Failing before

I applied the new regression test to unmodified upstream master and ran `test/extended_jump_array.jl` in a resolved local test environment:

```text
Extended problems preserve specialization: Test Failed
Evaluated: AutoSpecialize == AutoDespecialize

Extended problems preserve specialization | 0 passed, 3 failed, 3 total
```

All three ODE/SDE/DDE cases lost `AutoDespecialize` before the source fix.

A same-system ModelingToolkit discriminator also showed that replacing only tunable parameters from `Float64` to `Float32` left the inner functions as `AutoSpecialize` and produced different solved problem/function types.

## Passing after

The identical regression file on the final commit exits successfully:

```text
Test Summary:                             | Pass  Total  Time
Extended problems preserve specialization |    3      3  1.2s
```

The full relevant group passed on the registered release graph (`SciMLBase 3.46.0`, `DiffEqBase 7.14.0`, `OrdinaryDiffEq 7.6.0`):

```sh
GROUP=InterfaceI julia +release --startup-file=no --project=. -e "using Pkg; Pkg.test(coverage=false)"
```

```text
ExtendedJumpArray Tests | 29 pass / 29 total
Testing JumpProcesses tests passed
2036.866942 seconds
```

The same-system discriminator after the fix reports both inner specializations as `AutoDespecialize` and equal solved problem/function types.

## Other verification

- JuliaFormatter 2.12.4 with `SciMLStyle`: idempotent on both changed files.
- `typos` over added lines: exit 0.
- `git diff --check`: exit 0.
- `GROUP=QA`: 16 pass / 1 fail. The sole failure is the unchanged clean-master public-reexport allowlist defect already isolated in https://github.com/SciML/JumpProcesses.jl/pull/623; ExplicitImports and all other QA checks pass.
- Docs were not built because this changes no public API or documentation.
- GPU and Julia pre were not run locally.