### PR TITLE
Fix variable-rate jumps for DAE problems

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -44,6 +44,7 @@ KernelAbstractions = "0.9.36"
 LinearAlgebra = "1"
 LinearSolve = "3.83.0, 5"
 OrdinaryDiffEq = "7.0.0, 7"
+OrdinaryDiffEqBDF = "2"
 OrdinaryDiffEqCore = "4.3.0, 4"
 OrdinaryDiffEqFunctionMap = "2.0.0, 2"
 Pkg = "1"
@@ -68,6 +69,7 @@ FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 LinearSolve = "7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
+OrdinaryDiffEqBDF = "6ad6398a-0878-4a85-9266-38940aa047c8"
 OrdinaryDiffEqFunctionMap = "d3585ca7-f5d3-4ba6-8057-292ed1abd90f"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
@@ -78,4 +80,4 @@ StochasticDiffEq = "789caeaf-c7a9-5a7d-9973-96adeb23e2a0"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["ADTypes", "FastBroadcast", "LinearAlgebra", "LinearSolve", "OrdinaryDiffEq", "OrdinaryDiffEqFunctionMap", "Pkg", "SafeTestsets", "SciMLTesting", "StableRNGs", "Statistics", "StochasticDiffEq", "Test"]
+test = ["ADTypes", "FastBroadcast", "LinearAlgebra", "LinearSolve", "OrdinaryDiffEq", "OrdinaryDiffEqBDF", "OrdinaryDiffEqFunctionMap", "Pkg", "SafeTestsets", "SciMLTesting", "StableRNGs", "Statistics", "StochasticDiffEq", "Test"]

--- a/src/variable_rate.jl
+++ b/src/variable_rate.jl
@@ -73,6 +73,12 @@ function extend_u0(prob, Njumps, rng)
     return u0
 end
 
+function extend_du0(prob, jumps)
+    t0 = first(prob.tspan)
+    jump_du0 = [jump.rate(prob.u0, prob.p, t0) for jump in jumps]
+    return ExtendedJumpArray(prob.du0, jump_du0)
+end
+
 function extend_problem(prob::SciMLBase.AbstractDiscreteProblem, jumps; rng = DEFAULT_RNG)
     error("General `VariableRateJump`s require a continuous problem, like an ODE/SDE/DDE/DAE problem. To use a `DiscreteProblem` bounded `VariableRateJump`s must be used. See the JumpProcesses docs.")
 end
@@ -165,31 +171,39 @@ function extend_problem(prob::SciMLBase.AbstractDDEProblem, jumps; rng = DEFAULT
     remake(prob; f, u0)
 end
 
-# Not sure if the DAE one is correct: Should be a residual of sorts
 function extend_problem(prob::SciMLBase.AbstractDAEProblem, jumps; rng = DEFAULT_RNG)
     _f = SciMLBase.unwrapped_f(prob.f)
 
     if isinplace(prob)
         jump_f = let _f = _f
-            function (out, du::ExtendedJumpArray, u::ExtendedJumpArray, h, p, t)
-                _f(out, du.u, u.u, h, p, t)
+            function (out::ExtendedJumpArray, du::ExtendedJumpArray,
+                    u::ExtendedJumpArray, p, t)
+                _f(out.u, du.u, u.u, p, t)
                 update_jumps!(out, u, p, t, length(u.u), jumps...)
+                out.jump_u .= du.jump_u .- out.jump_u
             end
         end
     else
         jump_f = let _f = _f
-            function (du, u::ExtendedJumpArray, h, p, t)
-                out = ExtendedJumpArray(_f(du.u, u.u, h, p, t), u.jump_u)
-                update_jumps!(du, u, p, t, length(u.u), jumps...)
-                return du
+            function (du::ExtendedJumpArray, u::ExtendedJumpArray, p, t)
+                jump_out = [du.jump_u[i] - jump.rate(u.u, p, t)
+                            for (i, jump) in enumerate(jumps)]
+                return ExtendedJumpArray(_f(du.u, u.u, p, t), jump_out)
             end
         end
     end
 
     u0 = extend_u0(prob, length(jumps), rng)
-    f = DAEFunction{isinplace(prob)}(jump_f, sys = prob.f.sys,
+    du0 = extend_du0(prob, jumps)
+    differential_vars = if prob.differential_vars === nothing
+        nothing
+    else
+        ExtendedJumpArray(prob.differential_vars, trues(length(jumps)))
+    end
+    f = DAEFunction{isinplace(prob), SciMLBase.specialization(prob.f)}(jump_f;
+        sys = prob.f.sys,
         observed = prob.f.observed)
-    remake(prob; f, u0)
+    remake(prob; f, du0, u0, differential_vars)
 end
 
 struct VR_FRMEventCallback{F, RNG}

--- a/test/extended_jump_array.jl
+++ b/test/extended_jump_array.jl
@@ -1,4 +1,5 @@
 using Test, JumpProcesses, DiffEqBase, OrdinaryDiffEq, SciMLBase, LinearAlgebra, LinearSolve
+using OrdinaryDiffEqBDF
 using FastBroadcast
 using StableRNGs
 
@@ -185,4 +186,40 @@ let
         rng = StableRNG(789))
     sol = solve(jprob, Rodas5P(linsolve = QRFactorization()))
     @test sol.retcode == ReturnCode.Success
+end
+
+@testset "DAE with VariableRateJump" begin
+    function dae!(out, du, u, p, t)
+        out .= du
+        nothing
+    end
+    dae(du, u, p, t) = du
+    rate(u, p, t) = u[1] + 1.0
+    affect!(integrator) = (integrator.u[1] += 1; nothing)
+    jump = VariableRateJump(rate, affect!)
+
+    for (f, iip) in ((dae!, true), (dae, false))
+        prob = DAEProblem{iip, SciMLBase.FullSpecialize}(
+            f, [0.0], [0.0], (0.0, 0.1);
+            differential_vars = [true])
+        jump_prob = JumpProblem(prob, Direct(), jump; vr_aggregator = VR_FRM(),
+            rng = StableRNG(626))
+        @test length(jump_prob.prob.du0) == length(jump_prob.prob.u0) == 2
+        @test length(jump_prob.prob.differential_vars) == 2
+        @test SciMLBase.specialization(jump_prob.prob.f) === SciMLBase.FullSpecialize
+
+        if isinplace(jump_prob.prob)
+            out = zero(jump_prob.prob.u0)
+            jump_prob.prob.f(
+                out, jump_prob.prob.du0, jump_prob.prob.u0, jump_prob.prob.p, 0.0)
+            @test all(iszero, out)
+
+            sol = solve(jump_prob, DFBDF())
+            @test sol.retcode == ReturnCode.Success
+        else
+            out = jump_prob.prob.f(
+                jump_prob.prob.du0, jump_prob.prob.u0, jump_prob.prob.p, 0.0)
+            @test all(iszero, out)
+        end
+    end
 end


### PR DESCRIPTION
> Please ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

`VR_FRM` extended a DAE's `u0` with the integrated jump-intensity states but left `du0` at its original size, so constructing the resulting `DAEProblem` threw a size mismatch. The DAE wrapper also still used DDE-style function signatures instead of the SciML DAE residual interface.

This extends `du0` and `differential_vars`, evaluates the augmented equations as `du_jump - rate(u, p, t) = 0`, and preserves the input `DAEFunction` specialization policy. The regression test covers in-place and out-of-place residual evaluation under `FullSpecialize`; it also solves the in-place problem with `DFBDF`.

The OrdinaryDiffEqBDF addition is test-only. It is MIT-licensed and adds no runtime dependency.

## Regression evidence

The same official test fails with `src/variable_rate.jl` restored to the unfixed version:

```text
$ julia +release --startup-file=no --project=. test/extended_jump_array.jl
ERROR: LoadError: Some tests did not pass: 0 passed, 0 failed, 1 errored, 0 broken.
ArgumentError: Sizes of u0 and du0 must be the same.
Test Summary:             | Error  Total  Time
DAE with VariableRateJump |     1      1  2.1s
```

With this commit applied:

```text
$ julia +release --startup-file=no --project=. test/extended_jump_array.jl
Test Summary:             | Pass  Total   Time
DAE with VariableRateJump |    9      9  17.3s
```

The historical boundary was bisected to https://github.com/SciML/JumpProcesses.jl/commit/a336dc63b30b5904939928a956a5c68c8c51bb94, which introduced the DAE `remake` with an extended `u0` but not `du0`. The original hybrid-problem work at https://github.com/SciML/JumpProcesses.jl/pull/72 requested DAE coverage but did not add it.

## Verification

```text
$ GROUP=InterfaceI JULIA_NUM_PRECOMPILE_TASKS=1 julia +release --startup-file=no --project=. -e 'using Pkg; Pkg.test(coverage=false)'
869 passed across 21 test blocks
Testing JumpProcesses tests passed

$ /home/crackauc/.julia/juliaup/julia-1.12.6+0.x64.linux.gnu/bin/julia --startup-file=no --project=/home/crackauc/.julia/environments/format-check -e 'using JuliaFormatter; format(".", SciMLStyle(), verbose=true)'
[JuliaFormatter 2.2.0; no tracked diff]

$ git diff --check
[exit 0]

$ git diff --unified=0 upstream/master...HEAD | typos -
[exit 0]
```

Local `GROUP=QA` currently reports 16 passed and 1 failed on both this branch and clean `upstream/master`: SciMLTesting 2.4 enabled the public-reexport check without a repository allowlist. The independent fix is https://github.com/SciML/JumpProcesses.jl/pull/623; it passes 17/17 locally on SciMLTesting 2.4 and 2.7. That mechanical QA change is intentionally not bundled here, so this PR's CI QA job is expected to remain red until that prerequisite merges.

CI reproduced only that expected failure: 16/17, with `No unapproved public reexports` as the sole failure in https://github.com/SciML/JumpProcesses.jl/actions/runs/31543893598/job/93952232035.

## Not verified

I did not run InterfaceII, GPU, Julia prerelease, or the full `Everything` matrix locally. The out-of-place DAE residual is evaluated directly by the regression test; an out-of-place `DFBDF` callback solve is not claimed because that solver configuration does not currently provide the callback's temporary-cache interface.

No documentation build was run because this changes no public API, docstring, or rendered documentation.

## Links

- DAE extension regression boundary: https://github.com/SciML/JumpProcesses.jl/commit/a336dc63b30b5904939928a956a5c68c8c51bb94
- Original hybrid DAE/DDE work: https://github.com/SciML/JumpProcesses.jl/pull/72
- Independent clean-master QA repair: https://github.com/SciML/JumpProcesses.jl/pull/623
- Expected QA failure on this PR: https://github.com/SciML/JumpProcesses.jl/actions/runs/31543893598/job/93952232035
