### PR TITLE
docs: enable Documenter doctests

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -21,7 +21,7 @@ mathengine = MathJax3(Dict(:loader => Dict("load" => ["[tex]/require", "[tex]/ma
         ])))
 
 makedocs(sitename = "JumpProcesses.jl", authors = "Chris Rackauckas", modules = [JumpProcesses],
-    clean = true, doctest = false, linkcheck = true, warnonly = [:missing_docs],
+    clean = true, linkcheck = true, warnonly = [:missing_docs],
     format = Documenter.HTML(; assets = ["assets/favicon.ico"],
         canonical = "https://docs.sciml.ai/JumpProcesses/",
         prettyurls = (get(ENV, "CI", nothing) == "true"),


### PR DESCRIPTION
Remove the repository-level `doctest = false` override so standard Documenter behavior executes the package's documented examples.

Verification:
- `julia --startup-file=no --project=docs -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'`
- `julia --startup-file=no --project=docs docs/make.jl` (passed with doctests enabled)
- `GROUP=QA julia --startup-file=no --project=. -e 'using Pkg; Pkg.test()'` (QA Tests: 17/17)
- `typos docs/make.jl`
- `git diff --check`

Formatter note: this repository's `Format Check` workflow is disabled. The current base `docs/make.jl` is already not clean under installed Runic or JuliaFormatter because of an unrelated existing MathJax3/makedocs formatting block; this PR leaves that block unchanged. Please ignore this draft until reviewed by @ChrisRackauckas.