### PR TITLE
docs: enforce exported API documentation checks

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -21,7 +21,7 @@ mathengine = MathJax3(Dict(:loader => Dict("load" => ["[tex]/require", "[tex]/ma
         ])))
 
 makedocs(sitename = "JumpProcesses.jl", authors = "Chris Rackauckas", modules = [JumpProcesses],
-    clean = true, linkcheck = true, warnonly = [:missing_docs],
+    clean = true, linkcheck = true, checkdocs = :exports,
     format = Documenter.HTML(; assets = ["assets/favicon.ico"],
         canonical = "https://docs.sciml.ai/JumpProcesses/",
         prettyurls = (get(ENV, "CI", nothing) == "true"),


### PR DESCRIPTION
> [!IMPORTANT]
> Please ignore this draft until it has been reviewed by @ChrisRackauckas.

## What changed

- Remove the repository-level `warnonly = [:missing_docs]` override.
- Set Documenter `checkdocs = :exports`, so missing exported API documentation remains fatal while internal implementation docstrings are outside the public manual check.
- Preserve the existing rendered API pages and doctests.

## Verification

- `GROUP=QA julia --startup-file=no --project=. -e 'using Pkg; Pkg.test()'`
  - `QA Tests | 17 17`; `Testing JumpProcesses tests passed`.
- `julia --startup-file=no --project=docs docs/make.jl`
  - Strict exported-doc checks passed, but local link checking stopped before rendering on the existing ColPrac URL returning HTTP 429: `https://github.com/SciML/ColPrac/blob/master/README.md`.
- Diagnostic local render with only `linkcheck = false` in an uncommitted temporary edit reached `HTMLWriter: rendering HTML pages`; rendered `docs/build/api` and tutorial HTML files were present. The committed configuration remains `linkcheck = true`.
- `julia --startup-file=no -e 'using Runic; Runic.main(["--check", "docs/make.jl"])'` passed.
- `typos docs/make.jl docs/Project.toml` passed.
- `git diff --check` passed.

No source code, public API, doctest, or failure suppression changes are included.
