### PR TITLE
Restore the SciML common interface on `using JumpProcesses`

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -79,3 +79,42 @@ neighbors
 num_sites
 outdegree
 ```
+
+## Reexported SciML common interface
+
+`using JumpProcesses` also brings in the parts of the SciML common interface needed to
+build the problem a [`JumpProblem`](@ref) wraps, solve it, drive the integrator from a
+jump's `affect!`, and inspect the result -- so they do not have to be imported
+separately. These names are owned and documented by
+[SciMLBase](https://docs.sciml.ai/SciMLBase/stable/); JumpProcesses only re-exports
+them:
+
+  - Problems: [`DiscreteProblem`](https://docs.sciml.ai/DiffEqDocs/stable/types/discrete_types/),
+    [`ODEProblem`](https://docs.sciml.ai/DiffEqDocs/stable/types/ode_types/),
+    [`SDEProblem`](https://docs.sciml.ai/DiffEqDocs/stable/types/sde_types/),
+    [`EnsembleProblem`](https://docs.sciml.ai/DiffEqDocs/stable/features/ensemble/),
+    `remake`, `NullParameters`
+  - Functions: `DiscreteFunction`, `ODEFunction`, `SDEFunction`
+  - Solutions: [`ODESolution`](https://docs.sciml.ai/DiffEqDocs/stable/basics/solution/),
+    `EnsembleSolution`, `EnsembleSummary`, and the `EnsembleAnalysis` module
+  - Ensemble algorithms: `EnsembleSerial`, `EnsembleThreads`, `EnsembleDistributed`,
+    `EnsembleSplitThreads`
+  - Solving: `solve`, `solve!`, `init`, `step!`
+  - Integrator interface: `add_tstop!`, `add_saveat!`, `savevalues!`,
+    `set_proposed_dt!`, `set_t!`, `set_u!`, `reinit!`, `terminate!`, `u_modified!`,
+    `derivative_discontinuity!`
+  - Return status: `ReturnCode`, `successful_retcode`
+  - [Callbacks](https://docs.sciml.ai/DiffEqDocs/stable/features/callback_functions/):
+    `DiscreteCallback`, `ContinuousCallback`, `VectorContinuousCallback`, `CallbackSet`
+
+`DiscreteProblem` and `EnsembleProblem` in particular are what most downstream code
+reaches for through JumpProcesses -- see SciML/MomentClosure.jl#111 for what happens
+when they are not re-exported.
+
+Note that [`SSAStepper`](@ref) only supports `DiscreteCallback`s;
+`ContinuousCallback` and `VectorContinuousCallback` are re-exported for use with the
+ODE/SDE integrators a `JumpProblem` can be paired with.
+
+Anything else from SciMLBase -- the BVP, DAE, DDE, nonlinear and optimization problem
+classes, the SciML operators, and the internals -- is not re-exported here; import it
+from SciMLBase directly.

--- a/docs/src/applications/advanced_point_process.md
+++ b/docs/src/applications/advanced_point_process.md
@@ -76,7 +76,7 @@ Therefore, we have that our structure includes a vector of sub-TPP
 connected graph `g`.
 
 ```@example tpp-advanced
-using JumpProcesses, SciMLBase
+using JumpProcesses
 using PointProcesses
 
 struct SciMLPointProcess{M, J <: JumpProcesses.AbstractJump, G, D, T <: Real} <:

--- a/docs/src/faq.md
+++ b/docs/src/faq.md
@@ -90,7 +90,7 @@ Internally, JumpProcesses SSAs (aggregators) order all `MassActionJump`s first,
 then all `ConstantRateJumps` and/or `VariableRateJumps`. i.e., in the example
 
 ```julia
-using JumpProcesses, SciMLBase
+using JumpProcesses
 rs = [[1 => 1], [2 => 1]]
 ns = [[1 => -1, 2 => 1], [1 => 1, 2 => -1]]
 p = [1.0, 0.0]
@@ -131,7 +131,7 @@ A simple example that uses a `MassActionJump` and changes the parameters at a
 specified time in the simulation using a `DiscreteCallback` is
 
 ```julia
-using JumpProcesses, SciMLBase
+using JumpProcesses
 rs = [[1 => 1], [2 => 1]]
 ns = [[1 => -1, 2 => 1], [1 => 1, 2 => -1]]
 p = [1.0, 0.0]

--- a/docs/src/tutorials/discrete_stochastic_example.md
+++ b/docs/src/tutorials/discrete_stochastic_example.md
@@ -50,7 +50,6 @@ not already installed, they can be added as follows:
 ```julia
 using Pkg
 Pkg.add("JumpProcesses")
-Pkg.add("SciMLBase")
 Pkg.add("OrdinaryDiffEq")
 Pkg.add("Plots")
 Pkg.add("Catalyst")                # optional
@@ -59,12 +58,12 @@ Pkg.add("Catalyst")                # optional
 Let's now load the required packages and set some default plot settings
 
 ```julia
-using JumpProcesses, SciMLBase, OrdinaryDiffEq, Plots, LinearAlgebra
+using JumpProcesses, OrdinaryDiffEq, Plots, LinearAlgebra
 default(; lw = 2)
 ```
 
 ```@setup tut2
-using JumpProcesses, SciMLBase, OrdinaryDiffEq, Plots, LinearAlgebra
+using JumpProcesses, OrdinaryDiffEq, Plots, LinearAlgebra
 default(; lw = 2)
 ```
 

--- a/docs/src/tutorials/jump_diffusion.md
+++ b/docs/src/tutorials/jump_diffusion.md
@@ -31,7 +31,6 @@ not already installed
 ```julia
 using Pkg
 Pkg.add("JumpProcesses")
-Pkg.add("SciMLBase")
 Pkg.add("OrdinaryDiffEq")
 Pkg.add("StochasticDiffEq")
 Pkg.add("Plots")
@@ -40,7 +39,7 @@ Pkg.add("Plots")
 We then load these packages, and set some plotting defaults, as
 
 ```@example tut3
-using JumpProcesses, SciMLBase, StochasticDiffEq, OrdinaryDiffEq, Plots
+using JumpProcesses, StochasticDiffEq, OrdinaryDiffEq, Plots
 default(; lw = 2)
 ```
 

--- a/docs/src/tutorials/point_process_simulation.md
+++ b/docs/src/tutorials/point_process_simulation.md
@@ -60,7 +60,7 @@ which is the simplest TPP process with ``\lambda(t) = 1``. Let's start by
 loading our packages.
 
 ```@example tpp-tutorial
-using JumpProcesses, SciMLBase, Plots
+using JumpProcesses, Plots
 ```
 
 In JumpProcesses, a `ConstantRateJump` is a TPP whose rate is constant

--- a/docs/src/tutorials/simple_poisson_process.md
+++ b/docs/src/tutorials/simple_poisson_process.md
@@ -26,14 +26,13 @@ installed via
 ```julia
 using Pkg
 Pkg.add("JumpProcesses")
-Pkg.add("SciMLBase")
 Pkg.add("Plots")
 ```
 
 Let's also load our packages and set some defaults for our plot formatting
 
 ```@example tut1
-using JumpProcesses, SciMLBase, Plots
+using JumpProcesses, Plots
 default(; lw = 2)
 ```
 
@@ -57,7 +56,7 @@ In the remainder of this tutorial we will use
 is the full program listing, which we will subsequently explain line by line
 
 ```julia
-using JumpProcesses, SciMLBase, Plots
+using JumpProcesses, Plots
 
 rate(u, p, t) = p.λ
 affect!(integrator) = (integrator.u[1] += 1)
@@ -78,7 +77,7 @@ We can define and simulate our jump process as follows. We first load our
 packages
 
 ```@example tut1
-using JumpProcesses, SciMLBase, Plots
+using JumpProcesses, Plots
 ```
 
 To specify our jump process, we need to define two functions. One that given the

--- a/docs/src/tutorials/spatial.md
+++ b/docs/src/tutorials/spatial.md
@@ -23,7 +23,7 @@ There are no $$C$$ molecules at the start.
 We first create the grid:
 
 ```@example spatial
-using JumpProcesses, SciMLBase
+using JumpProcesses
 dims = (5, 5)
 num_nodes = prod(dims) # number of sites
 grid = CartesianGrid(dims) # or use Graphs.grid(dims)

--- a/src/JumpProcesses.jl
+++ b/src/JumpProcesses.jl
@@ -35,12 +35,22 @@ import RecursiveArrayTools: recursivecopy!
 import SymbolicIndexingInterface as SII
 
 # Import additional types and functions from DiffEqBase and SciMLBase
-using DiffEqBase: DiffEqBase, CallbackSet, ContinuousCallback, DAEFunction,
-                  DDEFunction, ODEFunction, ODEProblem,
-                  ODESolution, ReturnCode, SDEFunction, SDEProblem, add_tstop!,
-                  isinplace, remake, savevalues!, step!,
-                  derivative_discontinuity!
-using SciMLBase: SciMLBase, DEIntegrator, DiscreteProblem
+using DiffEqBase: DiffEqBase, DAEFunction, DDEFunction, isinplace
+using SciMLBase: SciMLBase, DEIntegrator
+
+# The SciML common interface that JumpProcesses reexports (see the second `export`
+# block below), so that `using JumpProcesses` on its own is enough to build the problem
+# a `JumpProblem` wraps, attach callbacks, solve it, drive the integrator from a jump
+# `affect!`, run ensembles, and inspect the result. Everything here stays owned and
+# documented upstream in SciMLBase.
+using SciMLBase: CallbackSet, ContinuousCallback, DiscreteFunction, DiscreteProblem,
+                 EnsembleAnalysis, EnsembleDistributed, EnsembleProblem, EnsembleSerial,
+                 EnsembleSolution, EnsembleSplitThreads, EnsembleSummary,
+                 EnsembleThreads, NullParameters, ODEFunction, ODEProblem, ODESolution,
+                 ReturnCode, SDEFunction, SDEProblem, VectorContinuousCallback,
+                 add_saveat!, add_tstop!, derivative_discontinuity!, reinit!, remake,
+                 savevalues!, set_proposed_dt!, set_t!, set_u!, step!,
+                 successful_retcode, terminate!, u_modified!
 
 abstract type AbstractJump end
 abstract type AbstractMassActionJump <: AbstractJump end
@@ -152,6 +162,16 @@ export JumpProblem, SplitCoupledJumpProblem
 
 include("solve.jl")
 export init, solve, solve!
+
+# Reexported SciML common interface; approved via `reexports_allow` in test/qa.jl.
+export CallbackSet, ContinuousCallback, DiscreteCallback, DiscreteFunction,
+       DiscreteProblem, EnsembleAnalysis, EnsembleDistributed, EnsembleProblem,
+       EnsembleSerial, EnsembleSolution, EnsembleSplitThreads, EnsembleSummary,
+       EnsembleThreads, NullParameters, ODEFunction, ODEProblem, ODESolution,
+       ReturnCode, SDEFunction, SDEProblem, VectorContinuousCallback, add_saveat!,
+       add_tstop!, derivative_discontinuity!, reinit!, remake, savevalues!,
+       set_proposed_dt!, set_t!, set_u!, step!, successful_retcode, terminate!,
+       u_modified!
 
 include("SSA_stepper.jl")
 export SSAStepper

--- a/test/qa.jl
+++ b/test/qa.jl
@@ -1,6 +1,20 @@
 using SciMLTesting, JumpProcesses
 
-const REEXPORTED_API = (:init, :solve, :solve!, :neighbors, :outdegree)
+# The SciML common interface JumpProcesses deliberately reexports so that
+# `using JumpProcesses` is enough to build, solve and inspect a jump problem. Owned and
+# documented upstream; kept in sync with the reexport `export` block in
+# src/JumpProcesses.jl. `neighbors`/`outdegree` are the Graphs.jl methods JumpProcesses
+# extends for its spatial grids.
+const REEXPORTED_API = (
+    :CallbackSet, :ContinuousCallback, :DiscreteCallback, :DiscreteFunction,
+    :DiscreteProblem, :EnsembleAnalysis, :EnsembleDistributed, :EnsembleProblem,
+    :EnsembleSerial, :EnsembleSolution, :EnsembleSplitThreads, :EnsembleSummary,
+    :EnsembleThreads, :NullParameters, :ODEFunction, :ODEProblem, :ODESolution,
+    :ReturnCode, :SDEFunction, :SDEProblem, :VectorContinuousCallback, :add_saveat!,
+    :add_tstop!, :derivative_discontinuity!, :init, :neighbors, :outdegree, :reinit!,
+    :remake, :savevalues!, :set_proposed_dt!, :set_t!, :set_u!, :solve, :solve!, :step!,
+    :successful_retcode, :terminate!, :u_modified!,
+)
 
 # The ExplicitImports ignore-lists below are names owned by other packages whose
 # released public API does not (yet) include them; each group is annotated with its


### PR DESCRIPTION
## What broke

`fdfd104` ("Allow intentional public reexports in QA", #623) replaced

```julia
@reexport using DiffEqBase
```

with a plain `using DiffEqBase`. The `reexports_allow` list that commit
introduced only covered the five names JumpProcesses already exported itself:

```julia
const REEXPORTED_API = (:init, :solve, :solve!, :neighbors, :outdegree)
```

Everything else that `using JumpProcesses` used to put in scope silently
disappeared from the public surface: `DiscreteProblem`, `ODEProblem`,
`SDEProblem`, `remake`, the callbacks, the ensemble types, and the integrator
functions a jump `affect!` calls. The package's own tests never noticed because
the same commit added explicit `using SciMLBase` / `using DiffEqBase` lines to
them.

## Evidence used to pick the names

1. **The stripping commit's own workarounds.** It had to add `using SciMLBase`
   (and `Pkg.add("SciMLBase")`) to seven documentation pages -- `simple_poisson_process.md`,
   `discrete_stochastic_example.md`, `jump_diffusion.md`, `point_process_simulation.md`,
   `spatial.md`, `faq.md`, `advanced_point_process.md` -- and `SciMLBase`/`DiffEqBase`
   imports to ~25 files under `test/`. Those additions are a direct list of names
   that used to come from the reexport.
2. **Confirmed downstream breakage.** MomentClosure.jl's `Core` test group started
   failing with `UndefVarError` for `DiscreteProblem` and `EnsembleProblem`, which it
   had been getting from `using JumpProcesses`. SciML/MomentClosure.jl#111 is a
   workaround that imports those two names from SciMLBase directly. That is this bug,
   observed in the wild.
3. **A token scan of `docs/src/**/*.md` and `test/**/*.jl`** against
   `setdiff(names(DiffEqBase), names(JumpProcesses))` (193 names lost). Hits in
   docs: `ContinuousCallback`, `DiscreteCallback`, `DiscreteProblem`,
   `EnsembleProblem`, `ODEProblem`, `ODESolution`, `SDEProblem`, `remake`. Hits
   in tests additionally: `CallbackSet`, `DiscreteFunction`, `EnsembleSerial`,
   `EnsembleThreads`, `ODEFunction`, `ReturnCode`, `add_tstop!`,
   `derivative_discontinuity!`, `reinit!`, `savevalues!`, `set_u!`, `step!`,
   `terminate!`.

Following the rule from SciML/Sundials.jl#553 -- reexport what normal
documented use needs, not whole dependencies -- this restores an explicit list
rather than the blanket reexport. The remaining ~155 DiffEqBase/SciMLBase names
(BVP/DAE/DDE/SDDE/optimization/nonlinear problem classes, traits, function
wrappers, internals) stay out.

## Restored names

```
CallbackSet, ContinuousCallback, DiscreteCallback, DiscreteFunction,
DiscreteProblem, EnsembleAnalysis, EnsembleDistributed, EnsembleProblem,
EnsembleSerial, EnsembleSolution, EnsembleSplitThreads, EnsembleSummary,
EnsembleThreads, NullParameters, ODEFunction, ODEProblem, ODESolution,
ReturnCode, SDEFunction, SDEProblem, VectorContinuousCallback, add_saveat!,
add_tstop!, derivative_discontinuity!, reinit!, remake, savevalues!,
set_proposed_dt!, set_t!, set_u!, step!, successful_retcode, terminate!,
u_modified!
```

(`init`, `solve`, `solve!`, `neighbors`, `outdegree` were already exported and
are unchanged.)

Each is imported from its owner `SciMLBase` rather than through DiffEqBase's
re-export, and `test/qa.jl`'s `reexports_allow` list is kept in sync with the
`export` block so it cannot drift.

The documentation pages go back to the documented `using JumpProcesses`.

## Documentation

`docs/src/api.md` gains a **Reexported SciML common interface** section listing the
names grouped by role -- problems / functions / solutions / ensemble algorithms /
solving / integrator interface / return status / callbacks -- with SciMLBase named as
their owner and links to the upstream docs for each group. It closes with the explicit
boundary line, and notes that `SSAStepper` only supports `DiscreteCallback`s so the
continuous callbacks are there for the ODE/SDE integrators a `JumpProblem` pairs with.

The docs list, the `export` block in `src/JumpProcesses.jl` and the `REEXPORTED_API`
tuple in `test/qa.jl` are now the same list in three places.

## Why this is not breaking

Every name here was exported by `using JumpProcesses` before `fdfd104`.
Restoring previously-exported names is additive -- no existing code changes
meaning. Per the release process, no version bump is included here.

## What was verified

- `julia --project=. -e 'using JumpProcesses'` loads, and all restored names are
  present in `names(JumpProcesses)`.
- A documented end-to-end workflow (`ConstantRateJump` + `DiscreteProblem` +
  `JumpProblem` + `solve(..., SSAStepper())`, plus `EnsembleProblem`/
  `EnsembleSerial` and `remake`) runs from a bare `using JumpProcesses`.
- `test/qa.jl` was run locally: **"No unapproved public reexports" passes**, as
  do `all_explicit_imports_via_owners`, `all_qualified_accesses_via_owners`,
  `all_explicit_imports_are_public`, Aqua and the public-API-documentation
  checks. The one erroring check, `all_qualified_accesses_are_public`, flags
  `Base.Iterators.filter`/`map` at `src/spatial/topology.jl:128` -- untouched by
  this PR and failing on master the same way with the ExplicitImports version
  resolved locally.
- The full test suite was **not** run locally (this machine is heavily loaded);
  CI covers it. This PR deliberately touches only `src/`, `docs/` and the
  `REEXPORTED_API` constant in `test/qa.jl`, to stay out of the way of the
  in-flight InterfaceI test work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rmh6B9eoW3N8oCbuuVPVxJ

