### PR TITLE
test: enable strict QA checks

### DIFF
--- a/ext/JumpProcessesOrdinaryDiffEqCoreExt.jl
+++ b/ext/JumpProcessesOrdinaryDiffEqCoreExt.jl
@@ -6,22 +6,23 @@ import SciMLBase
 import OrdinaryDiffEqCore: OrdinaryDiffEqAlgorithm, DAEAlgorithm,
     StochasticDiffEqAlgorithm, StochasticDiffEqRODEAlgorithm
 
-# Ambiguity fix: OrdinaryDiffEqCore defines
-#   __init(::Union{..., AbstractJumpProblem}, ::Union{OrdinaryDiffEqAlgorithm,
-#          DAEAlgorithm, StochasticDiffEqAlgorithm, StochasticDiffEqRODEAlgorithm})
-# which is ambiguous with JumpProcesses'
-#   __init(::AbstractJumpProblem{P}, ::DEAlgorithm)
-#
-# This method resolves the ambiguity by being more specific in the problem type
-# (AbstractJumpProblem vs Union{..., AbstractJumpProblem, ...}) while matching
-# the exact algorithm union from OrdinaryDiffEqCore.
-function SciMLBase.__init(
-        _jump_prob::SciMLBase.AbstractJumpProblem{P},
-        alg::Union{OrdinaryDiffEqAlgorithm, DAEAlgorithm,
-            StochasticDiffEqAlgorithm, StochasticDiffEqRODEAlgorithm};
-        merge_callbacks = true, kwargs...) where {P}
+function _jump_init(_jump_prob, alg; merge_callbacks = true, kwargs...)
     kwargs = DiffEqBase.merge_problem_kwargs(_jump_prob; merge_callbacks, kwargs...)
     JumpProcesses.__jump_init(_jump_prob, alg; kwargs...)
+end
+
+function SciMLBase.__init(
+        _jump_prob::JumpProcesses.JumpProblem{IIP, P},
+        alg::Union{OrdinaryDiffEqAlgorithm, DAEAlgorithm};
+        kwargs...) where {IIP, P}
+    _jump_init(_jump_prob, alg; kwargs...)
+end
+
+function SciMLBase.__init(
+        _jump_prob::JumpProcesses.JumpProblem{IIP, P},
+        alg::Union{StochasticDiffEqAlgorithm, StochasticDiffEqRODEAlgorithm};
+        kwargs...) where {IIP, P}
+    _jump_init(_jump_prob, alg; kwargs...)
 end
 
 end

--- a/src/aggregators/ccnrm.jl
+++ b/src/aggregators/ccnrm.jl
@@ -66,7 +66,7 @@ function aggregate(aggregator::CCNRM, u, p, t, end_time, constant_jumps,
 end
 
 # set up a new simulation and calculate the first jump / jump time
-function initialize!(p::CCNRMJumpAggregation, integrator, u, params, t)
+function initialize!(p::CCNRMJumpAggregation, integrator, u, params, t::Number)
     p.end_time = integrator.sol.prob.tspan[2]
     initialize_rates_and_times!(p, u, params, t)
     generate_jumps!(p, integrator, u, params, t)

--- a/src/aggregators/coevolve.jl
+++ b/src/aggregators/coevolve.jl
@@ -147,7 +147,7 @@ function aggregate(aggregator::Coevolve, u, p, t, end_time, constant_jumps,
 end
 
 # set up a new simulation and calculate the first jump / jump time
-function initialize!(p::CoevolveJumpAggregation, integrator, u, params, t)
+function initialize!(p::CoevolveJumpAggregation, integrator, u, params, t::Number)
     p.end_time = integrator.sol.prob.tspan[2]
     fill_rates_and_get_times!(p, u, params, t)
     generate_jumps!(p, integrator, u, params, t)

--- a/src/aggregators/direct.jl
+++ b/src/aggregators/direct.jl
@@ -45,7 +45,7 @@ function aggregate(aggregator::DirectFW, u, p, t, end_time, constant_jumps,
 end
 
 # set up a new simulation and calculate the first jump / jump time
-function initialize!(p::DirectJumpAggregation, integrator, u, params, t)
+function initialize!(p::DirectJumpAggregation, integrator, u, params, t::Number)
     p.end_time = integrator.sol.prob.tspan[2]
     generate_jumps!(p, integrator, u, params, t)
     nothing

--- a/src/aggregators/directcr.jl
+++ b/src/aggregators/directcr.jl
@@ -85,7 +85,7 @@ function aggregate(aggregator::DirectCR, u, p, t, end_time, constant_jumps,
 end
 
 # set up a new simulation and calculate the first jump / jump time
-function initialize!(p::DirectCRJumpAggregation, integrator, u, params, t)
+function initialize!(p::DirectCRJumpAggregation, integrator, u, params, t::Number)
     p.end_time = integrator.sol.prob.tspan[2]
 
     # initialize rates

--- a/src/aggregators/frm.jl
+++ b/src/aggregators/frm.jl
@@ -47,7 +47,7 @@ function aggregate(aggregator::FRMFW, u, p, t, end_time, constant_jumps,
 end
 
 # set up a new simulation and calculate the first jump / jump time
-function initialize!(p::FRMJumpAggregation, integrator, u, params, t)
+function initialize!(p::FRMJumpAggregation, integrator, u, params, t::Number)
     p.end_time = integrator.sol.prob.tspan[2]
     generate_jumps!(p, integrator, u, params, t)
     nothing

--- a/src/aggregators/nrm.jl
+++ b/src/aggregators/nrm.jl
@@ -60,7 +60,7 @@ function aggregate(aggregator::NRM, u, p, t, end_time, constant_jumps,
 end
 
 # set up a new simulation and calculate the first jump / jump time
-function initialize!(p::NRMJumpAggregation, integrator, u, params, t)
+function initialize!(p::NRMJumpAggregation, integrator, u, params, t::Number)
     p.end_time = integrator.sol.prob.tspan[2]
     fill_rates_and_get_times!(p, u, params, t)
     generate_jumps!(p, integrator, u, params, t)

--- a/src/aggregators/rdirect.jl
+++ b/src/aggregators/rdirect.jl
@@ -64,7 +64,7 @@ function aggregate(aggregator::RDirect, u, p, t, end_time, constant_jumps,
 end
 
 # set up a new simulation and calculate the first jump / jump time
-function initialize!(p::RDirectJumpAggregation, integrator, u, params, t)
+function initialize!(p::RDirectJumpAggregation, integrator, u, params, t::Number)
     p.end_time = integrator.sol.prob.tspan[2]
     fill_rates_and_sum!(p, u, params, t)
     p.max_rate = maximum(p.cur_rates)

--- a/src/aggregators/rssa.jl
+++ b/src/aggregators/rssa.jl
@@ -85,7 +85,7 @@ function aggregate(aggregator::RSSA, u, p, t, end_time, constant_jumps,
 end
 
 # set up a new simulation and calculate the first jump / jump time
-function initialize!(p::RSSAJumpAggregation, integrator, u, params, t)
+function initialize!(p::RSSAJumpAggregation, integrator, u, params, t::Number)
     p.end_time = integrator.sol.prob.tspan[2]
     set_bracketing!(p, u, params, t)
     generate_jumps!(p, integrator, u, params, t)

--- a/src/aggregators/rssacr.jl
+++ b/src/aggregators/rssacr.jl
@@ -102,7 +102,7 @@ function aggregate(aggregator::RSSACR, u, p, t, end_time, constant_jumps,
 end
 
 # set up a new simulation and calculate the first jump / jump time
-function initialize!(p::RSSACRJumpAggregation, integrator, u, params, t)
+function initialize!(p::RSSACRJumpAggregation, integrator, u, params, t::Number)
     p.end_time = integrator.sol.prob.tspan[2]
     set_bracketing!(p, u, params, t)
 

--- a/src/aggregators/sortingdirect.jl
+++ b/src/aggregators/sortingdirect.jl
@@ -64,7 +64,7 @@ function aggregate(aggregator::SortingDirect, u, p, t, end_time, constant_jumps,
 end
 
 # set up a new simulation and calculate the first jump / jump time
-function initialize!(p::SortingDirectJumpAggregation, integrator, u, params, t)
+function initialize!(p::SortingDirectJumpAggregation, integrator, u, params, t::Number)
     p.end_time = integrator.sol.prob.tspan[2]
     fill_rates_and_sum!(p, u, params, t)
     generate_jumps!(p, integrator, u, params, t)

--- a/src/extended_jump_array.jl
+++ b/src/extended_jump_array.jl
@@ -90,7 +90,8 @@ end
 Base.zero(A::ExtendedJumpArray) = fill!(similar(A), 0)
 
 # Required for non-diagonal noise; also handles full-state matrices from LinearSolve
-function LinearAlgebra.mul!(c::ExtendedJumpArray, A::AbstractVecOrMat, u::AbstractVector)
+function _mul_extended_jump_array!(c::ExtendedJumpArray, A::AbstractVecOrMat,
+        u::AbstractVector)
     Nu = length(c.u)
     if size(A, 1) == Nu
         mul!(c.u, A, u)
@@ -105,6 +106,12 @@ function LinearAlgebra.mul!(c::ExtendedJumpArray, A::AbstractVecOrMat, u::Abstra
         throw(DimensionMismatch("first dimension of A, $(size(A,1)), does not match length of c.u, $Nu, or length of c, $(length(c))"))
     end
 end
+
+LinearAlgebra.mul!(c::ExtendedJumpArray, A::AbstractVecOrMat, u::AbstractVector) =
+    _mul_extended_jump_array!(c, A, u)
+
+LinearAlgebra.mul!(c::ExtendedJumpArray, A::LinearAlgebra.AbstractTriangular,
+    u::AbstractVector) = _mul_extended_jump_array!(c, A, u)
 
 # Ignore axes
 function Base.similar(A::ExtendedJumpArray, ::Type{S},
@@ -139,8 +146,19 @@ end
 function LinearAlgebra.ldiv!(A::LinearAlgebra.LU, b::ExtendedJumpArray)
     _eja_flat_apply_and_scatter!(LinearAlgebra.ldiv!, A, b)
 end
+function LinearAlgebra.ldiv!(A::LinearAlgebra.LU{T, LinearAlgebra.Tridiagonal{T, V}},
+        b::ExtendedJumpArray) where {T, V}
+    _eja_flat_apply_and_scatter!(LinearAlgebra.ldiv!, A, b)
+end
 
 function LinearAlgebra.lmul!(A::LinearAlgebra.AbstractQ, b::ExtendedJumpArray)
+    _eja_flat_apply_and_scatter!(LinearAlgebra.lmul!, A, b)
+end
+function LinearAlgebra.lmul!(A::LinearAlgebra.QRPackedQ, b::ExtendedJumpArray)
+    _eja_flat_apply_and_scatter!(LinearAlgebra.lmul!, A, b)
+end
+function LinearAlgebra.lmul!(A::LinearAlgebra.AdjointQ{<:Any, <:LinearAlgebra.QRPackedQ},
+        b::ExtendedJumpArray)
     _eja_flat_apply_and_scatter!(LinearAlgebra.lmul!, A, b)
 end
 

--- a/src/jumps.jl
+++ b/src/jumps.jl
@@ -568,6 +568,10 @@ end
 function JumpSet(vj, cj, rj, maj::MassActionJump{S, T, U, V}) where {S <: Number, T, U, V}
     JumpSet(vj, cj, rj, check_majump_type(maj))
 end
+function JumpSet(vj::AbstractJump, cj::AbstractJump, rj::AbstractJump,
+        maj::MassActionJump{S, T, U, V}) where {S <: Number, T, U, V}
+    JumpSet(vj, cj, rj, check_majump_type(maj))
+end
 
 JumpSet(jump::ConstantRateJump) = JumpSet((), (jump,), nothing, nothing)
 JumpSet(jump::VariableRateJump) = JumpSet((jump,), (), nothing, nothing)

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -1,6 +1,6 @@
-function SciMLBase.__solve(jump_prob::SciMLBase.AbstractJumpProblem{P},
+function SciMLBase.__solve(jump_prob::JumpProblem{IIP, P},
         alg::SciMLBase.AbstractDEAlgorithm;
-        merge_callbacks = true, kwargs...) where {P}
+        merge_callbacks = true, kwargs...) where {IIP, P}
     # Merge jump_prob.kwargs with passed kwargs
     kwargs = DiffEqBase.merge_problem_kwargs(jump_prob; merge_callbacks, kwargs...)
 
@@ -9,10 +9,9 @@ function SciMLBase.__solve(jump_prob::SciMLBase.AbstractJumpProblem{P},
     integrator.sol
 end
 
-#Ambiguity Fix
-function SciMLBase.__solve(jump_prob::SciMLBase.AbstractJumpProblem{P},
+function SciMLBase.__solve(jump_prob::JumpProblem{IIP, P},
         alg::Union{SciMLBase.AbstractRODEAlgorithm, SciMLBase.AbstractSDEAlgorithm};
-        merge_callbacks = true, kwargs...) where {P}
+        merge_callbacks = true, kwargs...) where {IIP, P}
     # Merge jump_prob.kwargs with passed kwargs
     kwargs = DiffEqBase.merge_problem_kwargs(jump_prob; merge_callbacks, kwargs...)
 
@@ -23,17 +22,17 @@ end
 
 # if passed a JumpProblem over a DiscreteProblem, and no aggregator is selected use
 # SSAStepper
-function SciMLBase.__solve(jump_prob::SciMLBase.AbstractJumpProblem{P};
-        kwargs...) where {P <: DiscreteProblem}
+function SciMLBase.__solve(jump_prob::JumpProblem{IIP, P};
+        kwargs...) where {IIP, P <: DiscreteProblem}
     SciMLBase.__solve(jump_prob, SSAStepper(); kwargs...)
 end
 
-function SciMLBase.__solve(jump_prob::SciMLBase.AbstractJumpProblem; kwargs...)
+function SciMLBase.__solve(jump_prob::JumpProblem; kwargs...)
     error("Auto-solver selection is currently only implemented for JumpProblems defined over DiscreteProblems. Please explicitly specify a solver algorithm in calling solve.")
 end
 
-function SciMLBase.__init(_jump_prob::SciMLBase.AbstractJumpProblem{P},
-        alg::SciMLBase.AbstractDEAlgorithm; merge_callbacks = true, kwargs...) where {P}
+function SciMLBase.__init(_jump_prob::JumpProblem{IIP, P},
+        alg::SciMLBase.AbstractDEAlgorithm; merge_callbacks = true, kwargs...) where {IIP, P}
     # Merge jump_prob.kwargs with passed kwargs
     kwargs = DiffEqBase.merge_problem_kwargs(_jump_prob; merge_callbacks, kwargs...)
 

--- a/src/spatial/directcrdirect.jl
+++ b/src/spatial/directcrdirect.jl
@@ -104,7 +104,7 @@ function aggregate(aggregator::DirectCRDirect, starting_state, p, t, end_time,
 end
 
 # set up a new simulation and calculate the first jump / jump time
-function initialize!(p::DirectCRDirectJumpAggregation, integrator, u, params, t)
+function initialize!(p::DirectCRDirectJumpAggregation, integrator, u, params, t::Number)
     p.end_time = integrator.sol.prob.tspan[2]
     fill_rates_and_get_times!(p, integrator, t)
     generate_jumps!(p, integrator, params, u, t)

--- a/src/spatial/nsm.jl
+++ b/src/spatial/nsm.jl
@@ -93,7 +93,7 @@ function aggregate(aggregator::NSM, starting_state, p, t, end_time, constant_jum
 end
 
 # set up a new simulation and calculate the first jump / jump time
-function initialize!(p::NSMJumpAggregation, integrator, u, params, t)
+function initialize!(p::NSMJumpAggregation, integrator, u, params, t::Number)
     p.end_time = integrator.sol.prob.tspan[2]
     fill_rates_and_get_times!(p, integrator, t)
     generate_jumps!(p, integrator, params, u, t)

--- a/src/spatial/spatial_massaction_jump.jl
+++ b/src/spatial/spatial_massaction_jump.jl
@@ -112,16 +112,32 @@ function SpatialMassActionJump(urates::A, srates::B, rs, ns; scale_rates = true,
         useiszero = useiszero, nocopy = nocopy)
 end
 
+function SpatialMassActionJump(::Nothing, srates::B, rs, ns;
+        scale_rates = true, useiszero = true, nocopy = false) where {B <: AMatOrNothing}
+    SpatialMassActionJump(nothing, srates, rs, ns, nothing;
+        scale_rates = scale_rates, useiszero = useiszero, nocopy = nocopy)
+end
+
 function SpatialMassActionJump(srates::B, rs, ns, pmapper; scale_rates = true,
         useiszero = true,
         nocopy = false) where {B <: AMatOrNothing}
     SpatialMassActionJump(nothing, srates, rs, ns, pmapper; scale_rates = scale_rates,
         useiszero = useiszero, nocopy = nocopy)
 end
+function SpatialMassActionJump(::Nothing, rs, ns, pmapper; scale_rates = true,
+        useiszero = true, nocopy = false)
+    SpatialMassActionJump(nothing, nothing, rs, ns, pmapper;
+        scale_rates = scale_rates, useiszero = useiszero, nocopy = nocopy)
+end
 function SpatialMassActionJump(srates::B, rs, ns; scale_rates = true, useiszero = true,
         nocopy = false) where {B <: AMatOrNothing}
     SpatialMassActionJump(nothing, srates, rs, ns, nothing; scale_rates = scale_rates,
         useiszero = useiszero, nocopy = nocopy)
+end
+function SpatialMassActionJump(::Nothing, rs, ns; scale_rates = true, useiszero = true,
+        nocopy = false)
+    SpatialMassActionJump(nothing, nothing, rs, ns, nothing;
+        scale_rates = scale_rates, useiszero = useiszero, nocopy = nocopy)
 end
 
 function SpatialMassActionJump(urates::A, rs, ns, pmapper; scale_rates = true,
@@ -169,6 +185,10 @@ function get_num_majumps(smaj::SpatialMassActionJump{
 end
 using_params(smaj::SpatialMassActionJump) = false
 
+function rate_at_site(rx, site,
+        smaj::SpatialMassActionJump{Nothing, Nothing})
+    throw(BoundsError(smaj, rx))
+end
 function rate_at_site(rx, site,
         smaj::SpatialMassActionJump{Nothing, B, S, U, V}) where {B, S, U, V}
     smaj.spatial_rates[rx, site]

--- a/src/spatial/topology.jl
+++ b/src/spatial/topology.jl
@@ -33,6 +33,8 @@ rand_nbr(rng, graph::AbstractGraph, site) = rand(rng, neighbors(graph, site))
 nth_nbr(graph::AbstractGraph, site, n) = @inbounds neighbors(graph, site)[n]
 
 ################### CartesianGrid ########################
+abstract type AbstractCartesianGrid end
+
 const offsets_1D = [CartesianIndex(-1), CartesianIndex(1)]
 const offsets_2D = [
     CartesianIndex(0, -1),
@@ -89,7 +91,7 @@ grid = CartesianGrid((2, 2))
 outdegree(grid, 1) == 2
 ```
 """
-outdegree(grid, site) = grid.nums_neighbors[site]
+outdegree(grid::AbstractCartesianGrid, site::Int) = grid.nums_neighbors[site]
 
 """
     nth_potential_nbr(grid, site, n)
@@ -121,7 +123,7 @@ end
 
 return an iterator over neighbors of site in ascending order. Do not use in hot loops
 """
-function neighbors(grid, site)
+function neighbors(grid::AbstractCartesianGrid, site::Int)
     CI = grid.CI
     LI = grid.LI
     I = CI[site]
@@ -211,7 +213,7 @@ outdegree(grid, 1) == 2
 collect(neighbors(grid, 1)) == [2, 3]
 ```
 """
-struct CartesianGridRej{N, T}
+struct CartesianGridRej{N, T} <: AbstractCartesianGrid
     "dimensions (side lengths) of the grid"
     dims::NTuple{N, Int}
 

--- a/test/extended_jump_array.jl
+++ b/test/extended_jump_array.jl
@@ -146,6 +146,15 @@ let rng = StableRNG(593)
     @test c.jump_u ≈ full[4:6]
 end
 
+let rng = StableRNG(621)
+    c = ExtendedJumpArray(zeros(3), zeros(1))
+    A = UpperTriangular(rand(rng, 3, 3))
+    u = rand(rng, 3)
+    mul!(c, A, u)
+    @test c.u ≈ A * u
+    @test all(iszero, c.jump_u)
+end
+
 # Test ldiv! and lmul! for stiff solver support
 let rng = StableRNG(456)
     u = rand(rng, 3)
@@ -159,6 +168,13 @@ let rng = StableRNG(456)
     expected = F \ flat
     ldiv!(F, eja)
     @test vcat(eja.u, eja.jump_u) ≈ expected
+
+    eja_tridiagonal = ExtendedJumpArray(copy(u), copy(jump_u))
+    tridiagonal = Tridiagonal(fill(-1.0, 4), fill(5.0, 5), fill(-1.0, 4))
+    tridiagonal_factorization = lu(tridiagonal)
+    expected_tridiagonal = tridiagonal_factorization \ flat
+    ldiv!(tridiagonal_factorization, eja_tridiagonal)
+    @test vcat(eja_tridiagonal.u, eja_tridiagonal.jump_u) ≈ expected_tridiagonal
 
     # lmul! with Q from QR
     eja2 = ExtendedJumpArray(copy(u), copy(jump_u))

--- a/test/qa.jl
+++ b/test/qa.jl
@@ -24,11 +24,6 @@ run_qa(
     JumpProcesses;
     explicit_imports = true,
     reexports_allow = REEXPORTED_API,
-    aqua_kwargs = (;
-        ambiguities = false,       # TODO: fix ambiguities and enable
-        piracies = false,          # default solvers defined for AbstractJumpProblem
-        persistent_tasks = false,  # disabled due to false positives
-    ),
     ei_kwargs = (;
         # Names not (yet) declared public in their owner package's released API.
         all_qualified_accesses_are_public = (;
@@ -45,7 +40,7 @@ run_qa(
                 # DiffEqBase non-public
                 :Stats,
                 # LinearAlgebra non-public
-                :AbstractQ,
+                :AbstractQ, :AdjointQ, :QRPackedQ,
                 # FunctionWrappers non-public
                 :FunctionWrapper,
             ),

--- a/test/spatial/spatial_majump.jl
+++ b/test/spatial/spatial_majump.jl
@@ -57,6 +57,12 @@ non_uniform_majumps_3 = SpatialMassActionJump(
     netstoch) # birth on the left, death on the right
 non_uniform_majumps = [non_uniform_majumps_1, non_uniform_majumps_2, non_uniform_majumps_3]
 
+empty_spatial_majump = SpatialMassActionJump(nothing, reactstoch, netstoch)
+empty_spatial_majump_with_mapper = SpatialMassActionJump(nothing, reactstoch, netstoch,
+    identity)
+@test get_num_majumps(empty_spatial_majump) == 0
+@test get_num_majumps(empty_spatial_majump_with_mapper) == 0
+
 # put together the JumpProblem's
 uniform_jump_problems = JumpProblem[JumpProblem(prob, NSM(), majump,
                                         hopping_constants = hopping_constants,


### PR DESCRIPTION
Removes the broad Aqua suppressions and fixes the underlying ambiguity and piracy reports. The ExplicitImports exceptions remain individual, owner-qualified names; `AdjointQ` and `QRPackedQ` are retained because LinearAlgebra exposes no public type that can express the required method intersections.

This PR also narrows JumpProcesses solver dispatch to its concrete `JumpProblem` type, resolves the extension intersection with StochasticDiffEqCore, and adds regressions for the affected LinearAlgebra and spatial constructors.

Ignore until reviewed by @ChrisRackauckas.

## Verification

- `Runic.main(["--check"; changed_files])` completed successfully.
- `typos` on the changed files completed successfully.
- `GROUP=QA julia --startup-file=no --project=. -e 'using Pkg; Pkg.test()'` passed: 20/20.\n- `GROUP=InterfaceII julia --startup-file=no --project=. -e 'using Pkg; Pkg.test()'` passed.\n\nA clean `master` checkout fails `GROUP=InterfaceI` in `test/precompile_workload.jl:18` with `28.0 == 21.0`; the same failure occurred before this branch and is not modified here.\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\nhttps://chatgpt.com/codex/tasks/019f4028-d2ae-7a12-aff0-7d996bd9c791