### PR TITLE
Add simple implicit tau-leaping algorithms

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -24,10 +24,12 @@ SymbolicIndexingInterface = "2efcf032-c050-4f8e-a9bb-153293bab1f5"
 
 [weakdeps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
 OrdinaryDiffEqCore = "bbf590c4-e513-4bbe-9b18-05decba2e5d8"
 
 [extensions]
+JumpProcessesForwardDiffExt = "ForwardDiff"
 JumpProcessesKernelAbstractionsExt = ["Adapt", "KernelAbstractions"]
 JumpProcessesOrdinaryDiffEqCoreExt = "OrdinaryDiffEqCore"
 
@@ -40,6 +42,7 @@ DiffEqBase = "7.5.5, 7"
 DiffEqCallbacks = "4.17.0"
 DocStringExtensions = "0.9.5"
 FastBroadcast = "1.3.2, 1"
+ForwardDiff = "0.10.36, 1"
 FunctionWrappers = "1.1.3"
 Graphs = "1.14.0"
 KernelAbstractions = "0.9.36"
@@ -67,6 +70,7 @@ julia = "1.10"
 
 [extras]
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 LinearSolve = "7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
@@ -80,4 +84,4 @@ StochasticDiffEq = "789caeaf-c7a9-5a7d-9973-96adeb23e2a0"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["FastBroadcast", "LinearAlgebra", "LinearSolve", "OrdinaryDiffEq", "OrdinaryDiffEqFunctionMap", "Pkg", "SafeTestsets", "SciMLTesting", "StableRNGs", "Statistics", "StochasticDiffEq", "Test"]
+test = ["FastBroadcast", "ForwardDiff", "LinearAlgebra", "LinearSolve", "OrdinaryDiffEq", "OrdinaryDiffEqFunctionMap", "Pkg", "SafeTestsets", "SciMLTesting", "StableRNGs", "Statistics", "StochasticDiffEq", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 version = "9.30.1"
 
 [deps]
+ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
@@ -17,6 +18,7 @@ PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
+SimpleNonlinearSolve = "727e6d20-b764-4bd8-a329-72de5adea6c7"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 SymbolicIndexingInterface = "2efcf032-c050-4f8e-a9bb-153293bab1f5"
 
@@ -54,6 +56,7 @@ RecursiveArrayTools = "4.3.0, 4"
 SafeTestsets = "0.1"
 SciMLBase = "3.18.0, 3.1"
 SciMLTesting = "2.8"
+SimpleNonlinearSolve = "2, 3"
 StableRNGs = "1"
 StaticArrays = "1.9.18"
 Statistics = "1"
@@ -63,7 +66,6 @@ Test = "1"
 julia = "1.10"
 
 [extras]
-ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 LinearSolve = "7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
@@ -78,4 +80,4 @@ StochasticDiffEq = "789caeaf-c7a9-5a7d-9973-96adeb23e2a0"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["ADTypes", "FastBroadcast", "LinearAlgebra", "LinearSolve", "OrdinaryDiffEq", "OrdinaryDiffEqFunctionMap", "Pkg", "SafeTestsets", "SciMLTesting", "StableRNGs", "Statistics", "StochasticDiffEq", "Test"]
+test = ["FastBroadcast", "LinearAlgebra", "LinearSolve", "OrdinaryDiffEq", "OrdinaryDiffEqFunctionMap", "Pkg", "SafeTestsets", "SciMLTesting", "StableRNGs", "Statistics", "StochasticDiffEq", "Test"]

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -65,11 +65,10 @@ VR_FRM
 
 ```@docs
 EnsembleGPUKernel
-NewtonImplicitSolver
 SimpleExplicitTauLeaping
 SimpleImplicitTauLeaping
 SimpleTauLeaping
-TrapezoidalImplicitSolver
+SimpleTrapezoidalLeaping
 ```
 
 ## Spatial Jump APIs

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -65,8 +65,11 @@ VR_FRM
 
 ```@docs
 EnsembleGPUKernel
+NewtonImplicitSolver
 SimpleExplicitTauLeaping
+SimpleImplicitTauLeaping
 SimpleTauLeaping
+TrapezoidalImplicitSolver
 ```
 
 ## Spatial Jump APIs

--- a/ext/JumpProcessesForwardDiffExt.jl
+++ b/ext/JumpProcessesForwardDiffExt.jl
@@ -1,0 +1,13 @@
+module JumpProcessesForwardDiffExt
+
+using JumpProcesses: ExtendedJumpArray
+import DiffEqBase
+import ForwardDiff
+
+@inline function DiffEqBase.ODE_DEFAULT_NORM(
+        u::ExtendedJumpArray{<:ForwardDiff.Dual}, t::ForwardDiff.Dual
+    )
+    return invoke(DiffEqBase.ODE_DEFAULT_NORM, Tuple{ExtendedJumpArray, Any}, u, t)
+end
+
+end

--- a/src/JumpProcesses.jl
+++ b/src/JumpProcesses.jl
@@ -36,7 +36,9 @@ import SymbolicIndexingInterface as SII
 
 # Import additional types and functions from DiffEqBase and SciMLBase
 using DiffEqBase: DiffEqBase, DAEFunction, DDEFunction, isinplace
-using SciMLBase: SciMLBase, DEIntegrator
+using SimpleNonlinearSolve: SimpleNonlinearSolve, SimpleNewtonRaphson
+using ADTypes: ADTypes, AutoFiniteDiff
+using SciMLBase: SciMLBase, DEIntegrator, NonlinearProblem
 
 # The SciML common interface that JumpProcesses reexports (see the second `export`
 # block below), so that `using JumpProcesses` on its own is enough to build the problem
@@ -178,7 +180,8 @@ export SSAStepper
 
 # leaping: 
 include("simple_regular_solve.jl")
-export SimpleTauLeaping, SimpleExplicitTauLeaping, EnsembleGPUKernel
+export SimpleTauLeaping, SimpleExplicitTauLeaping, SimpleImplicitTauLeaping,
+       NewtonImplicitSolver, TrapezoidalImplicitSolver, EnsembleGPUKernel
 
 # spatial:
 include("spatial/spatial_massaction_jump.jl")

--- a/src/JumpProcesses.jl
+++ b/src/JumpProcesses.jl
@@ -181,7 +181,7 @@ export SSAStepper
 # leaping: 
 include("simple_regular_solve.jl")
 export SimpleTauLeaping, SimpleExplicitTauLeaping, SimpleImplicitTauLeaping,
-       NewtonImplicitSolver, TrapezoidalImplicitSolver, EnsembleGPUKernel
+    SimpleTrapezoidalLeaping, EnsembleGPUKernel
 
 # spatial:
 include("spatial/spatial_massaction_jump.jl")

--- a/src/simple_regular_solve.jl
+++ b/src/simple_regular_solve.jl
@@ -77,43 +77,7 @@ end
 SimpleExplicitTauLeaping(; epsilon = 0.05) = SimpleExplicitTauLeaping(epsilon)
 
 """
-$(TYPEDEF)
-
-Abstract supertype for the nonlinear formulations
-[`SimpleImplicitTauLeaping`](@ref) can solve at each step.
-"""
-abstract type AbstractImplicitSolver end
-
-"""
-$(TYPEDEF)
-
-Solve each implicit tau-leaping step in its unmodified, fully implicit form,
-
-```math
-X(t + \\tau) = X(t) + \\sum_j \\nu_j a_j(X(t + \\tau)) \\tau
-```
-
-as in Rathinam et al. (2003) and Cao et al. (2004).
-"""
-struct NewtonImplicitSolver <: AbstractImplicitSolver end
-
-"""
-$(TYPEDEF)
-
-Solve each implicit tau-leaping step in trapezoidal form, averaging the
-propensities at the current and the new state,
-
-```math
-X(t + \\tau) = X(t) + \\sum_j \\nu_j \\frac{a_j(X(t)) + a_j(X(t + \\tau))}{2} \\tau.
-```
-
-The trapezoidal formulation damps the excessive stiffness of the fully implicit
-step and keeps the equilibrium distribution closer to the exact one.
-"""
-struct TrapezoidalImplicitSolver <: AbstractImplicitSolver end
-
-"""
-$(TYPEDEF)
+    SimpleImplicitTauLeaping(; epsilon = 0.05)
 
 An implicit tau-leaping method for stiff pure-jump problems.
 
@@ -125,6 +89,12 @@ lifts that restriction; see Rathinam et al. (2003) and Cao et al. (2004).
 The deterministic part of the step is taken implicitly and the fluctuations are
 then sampled with Poisson random variables, after which the step is rejected and
 `tau` halved if it would drive a population negative.
+
+```math
+X(t + \\tau) = X(t) + \\sum_j \\nu_j a_j(X(t + \\tau)) \\tau
+```
+
+as in Rathinam et al. (2003) and Cao et al. (2004).
 
 ## Fields
 
@@ -147,17 +117,54 @@ jprob = JumpProblem(prob, PureLeaping(), maj)
 sol = solve(jprob, SimpleImplicitTauLeaping())
 ```
 """
-struct SimpleImplicitTauLeaping{T <: AbstractFloat, S <: AbstractImplicitSolver} <:
-       SciMLBase.AbstractDEAlgorithm
+struct SimpleImplicitTauLeaping{T <: AbstractFloat} <: SciMLBase.AbstractDEAlgorithm
     """Error control parameter used when selecting `tau`."""
     epsilon::T
-    """The nonlinear formulation solved at each step."""
-    solver::S
 end
 
-function SimpleImplicitTauLeaping(; epsilon = 0.05, solver = NewtonImplicitSolver())
-    SimpleImplicitTauLeaping(epsilon, solver)
+SimpleImplicitTauLeaping(; epsilon = 0.05) = SimpleImplicitTauLeaping(epsilon)
+
+"""
+    SimpleTrapezoidalLeaping(; epsilon = 0.05)
+
+An implicit trapezoidal tau-leaping method for stiff pure-jump problems.
+
+The method averages the propensities at the current and new states,
+
+```math
+X(t + \\tau) = X(t) + \\sum_j \\nu_j \\frac{a_j(X(t)) + a_j(X(t + \\tau))}{2} \\tau.
+```
+
+This formulation damps the excessive stiffness of the fully implicit step and
+keeps the equilibrium distribution closer to the exact one.
+
+## Fields
+
+$(FIELDS)
+
+## Notes
+
+  - Only works with `JumpProblem`s defined from `DiscreteProblem`s that contain
+    only a `MassActionJump`, built with the `PureLeaping()` aggregator.
+  - Supports `saveat`, `save_start` and `save_end`.
+
+## Examples
+
+```julia
+using JumpProcesses
+
+maj = MassActionJump([1.0, 1.0], [[1 => 1], [2 => 1]], [[1 => -1, 2 => 1], [1 => 1, 2 => -1]])
+prob = DiscreteProblem([100, 100], (0.0, 10.0))
+jprob = JumpProblem(prob, PureLeaping(), maj)
+sol = solve(jprob, SimpleTrapezoidalLeaping())
+```
+"""
+struct SimpleTrapezoidalLeaping{T <: AbstractFloat} <: SciMLBase.AbstractDEAlgorithm
+    """Error control parameter used when selecting `tau`."""
+    epsilon::T
 end
+
+SimpleTrapezoidalLeaping(; epsilon = 0.05) = SimpleTrapezoidalLeaping(epsilon)
 
 function validate_pure_leaping_inputs(jump_prob::JumpProblem, alg)
     if !(jump_prob.aggregator isa PureLeaping)
@@ -173,8 +180,13 @@ function validate_pure_leaping_inputs(jump_prob::JumpProblem, alg)
         jump_prob.regular_jump !== nothing
 end
 
-function validate_pure_leaping_inputs(jump_prob::JumpProblem,
-        alg::Union{SimpleExplicitTauLeaping, SimpleImplicitTauLeaping})
+function validate_pure_leaping_inputs(
+        jump_prob::JumpProblem,
+        alg::Union{
+            SimpleExplicitTauLeaping, SimpleImplicitTauLeaping,
+            SimpleTrapezoidalLeaping,
+        }
+    )
     if !(jump_prob.aggregator isa PureLeaping)
         @warn "When using $alg, please pass PureLeaping() as the aggregator to the \
         JumpProblem, i.e. call JumpProblem(::DiscreteProblem, PureLeaping(),...). \
@@ -559,19 +571,13 @@ function DiffEqBase.solve(jump_prob::JumpProblem, alg::SimpleExplicitTauLeaping;
     return sol
 end
 
-# Residual of the implicit step, written so that the root u_new is the state at
-# t + tau. `params` carries a preallocated propensity cache for each of the two
-# states so that repeated residual evaluations do not allocate.
-#
-#   Newton:      u_new = u_current + sum_j nu_j a_j(u_new) tau
-#   Trapezoidal: u_new = u_current + sum_j nu_j (a_j(u_current) + a_j(u_new))/2 tau
 function implicit_equation!(resid, u_new, params)
-    (; u_current, rate_new, rate_current, nu, p, t, tau, rate, numjumps, solver) = params
+    (; u_current, rate_new, rate_current, nu, p, t, tau, rate, numjumps, alg) = params
 
     rate(rate_new, u_new, p, t + tau)
     resid .= u_new .- u_current
 
-    if solver isa NewtonImplicitSolver
+    if alg isa SimpleImplicitTauLeaping
         for j in 1:numjumps
             for spec_idx in axes(nu, 1)
                 resid[spec_idx] -= nu[spec_idx, j] * rate_new[j] * tau
@@ -583,22 +589,24 @@ function implicit_equation!(resid, u_new, params)
         for j in 1:numjumps
             for spec_idx in axes(nu, 1)
                 resid[spec_idx] -= nu[spec_idx, j] * half *
-                                   (rate_new[j] + rate_current[j]) * tau
+                    (rate_new[j] + rate_current[j]) * tau
             end
         end
     end
-    nothing
+    return nothing
 end
 
-# Solve one implicit step for the state at t + tau. Returns the new state and
-# whether the nonlinear solve converged.
-function solve_implicit(u_current, rate_new, rate_current, nu, p, t, tau, rate, numjumps,
-        solver)
+function solve_implicit(
+        u_current, rate_new, rate_current, nu, p, t, tau, rate, numjumps,
+        alg
+    )
     u_guess = convert(Vector{float(eltype(u_current))}, u_current)
-    params = (; u_current, rate_new, rate_current, nu, p, t, tau, rate, numjumps, solver)
+    params = (; u_current, rate_new, rate_current, nu, p, t, tau, rate, numjumps, alg)
     prob = NonlinearProblem(implicit_equation!, u_guess, params)
-    sol = solve(prob, SimpleNewtonRaphson(autodiff = AutoFiniteDiff());
-        abstol = 1e-6, reltol = 1e-6)
+    sol = solve(
+        prob, SimpleNewtonRaphson(autodiff = AutoFiniteDiff());
+        abstol = 1.0e-6, reltol = 1.0e-6
+    )
     return sol.u, SciMLBase.successful_retcode(sol)
 end
 
@@ -606,7 +614,8 @@ function simple_implicit_tau_leaping_loop!(
         prob, alg, u_current, u_new, t_current, t_end, p, rng,
         rate, nu, hor, max_hor, max_stoich, numjumps, epsilon,
         dtmin, saveat_times, usave, tsave, du, counts, rate_cache, rate_current, maj,
-        solver, save_end)
+        save_end
+    )
     save_idx = 1
 
     # Upper bound carried across iterations. Unlike the explicit loop, whose
@@ -621,20 +630,27 @@ function simple_implicit_tau_leaping_loop!(
             t_current = t_end
             break
         end
-        tau = compute_tau(u_current, rate_cache, nu, hor, p, t_current,
-            epsilon, rate, dtmin, max_hor, max_stoich, numjumps)
+        tau = compute_tau(
+            u_current, rate_cache, nu, hor, p, t_current,
+            epsilon, rate, dtmin, max_hor, max_stoich, numjumps
+        )
         tau = min(tau, tau_cap, t_end - t_current)
         if !isempty(saveat_times) && save_idx <= length(saveat_times) &&
-           t_current + tau > saveat_times[save_idx]
+                t_current + tau > saveat_times[save_idx]
             tau = saveat_times[save_idx] - t_current
         end
 
-        u_predicted, converged = solve_implicit(u_current, rate_cache, rate_current, nu, p,
-            t_current, tau, rate, numjumps, solver)
+        u_predicted, converged = solve_implicit(
+            u_current, rate_cache, rate_current, nu, p,
+            t_current, tau, rate, numjumps, alg
+        )
         if !converged
-            tau <= dtmin &&
-                error("SimpleImplicitTauLeaping failed to converge at t = $t_current " *
-                      "with the smallest permitted step dtmin = $dtmin.")
+            if tau <= dtmin
+                error(
+                    "$(nameof(typeof(alg))) failed to converge at t = $t_current " *
+                        "with the smallest permitted step dtmin = $dtmin."
+                )
+            end
             tau_cap = tau / 2
             continue
         end
@@ -644,7 +660,7 @@ function simple_implicit_tau_leaping_loop!(
         for j in eachindex(counts)
             scaled = rate_cache[j] * tau
             counts[j] = scaled <= zero(scaled) ? zero(eltype(counts)) :
-                        pois_rand(rng, scaled)
+                pois_rand(rng, scaled)
         end
 
         du .= 0
@@ -662,9 +678,8 @@ function simple_implicit_tau_leaping_loop!(
         end
         t_new = t_current + tau
 
-        # Save state if at a saveat time or if saveat is empty
         if isempty(saveat_times) ||
-           (save_idx <= length(saveat_times) && t_new >= saveat_times[save_idx])
+                (save_idx <= length(saveat_times) && t_new >= saveat_times[save_idx])
             push!(usave, copy(u_new))
             push!(tsave, t_new)
             if !isempty(saveat_times) && t_new >= saveat_times[save_idx]
@@ -677,26 +692,29 @@ function simple_implicit_tau_leaping_loop!(
         tau_cap = typemax(typeof(t_current))  # release the bound after a good step
     end
 
-    # Save endpoint if requested and not already saved
     if save_end && (isempty(tsave) || tsave[end] != t_end)
         push!(usave, copy(u_current))
         push!(tsave, t_end)
     end
+    return nothing
 end
 
-function DiffEqBase.solve(jump_prob::JumpProblem, alg::SimpleImplicitTauLeaping;
+function DiffEqBase.solve(
+        jump_prob::JumpProblem,
+        alg::Union{SimpleImplicitTauLeaping, SimpleTrapezoidalLeaping};
         seed = nothing,
         dtmin = nothing,
-        saveat = nothing, save_start = nothing, save_end = nothing)
+        saveat = nothing, save_start = nothing, save_end = nothing
+    )
     validate_pure_leaping_inputs(jump_prob, alg) ||
-        error("SimpleImplicitTauLeaping can only be used with PureLeaping JumpProblem with a MassActionJump.")
+        error("$(nameof(typeof(alg))) can only be used with PureLeaping JumpProblem with a MassActionJump.")
 
     prob = jump_prob.prob
     rng = jump_prob.rng
     tspan = prob.tspan
 
     if dtmin === nothing
-        dtmin = 1e-10 * one(typeof(tspan[2]))
+        dtmin = 1.0e-10 * one(typeof(tspan[2]))
     end
 
     (seed !== nothing) && seed!(rng, seed)
@@ -709,7 +727,6 @@ function DiffEqBase.solve(jump_prob::JumpProblem, alg::SimpleImplicitTauLeaping;
 
     saveat_times, save_start, save_end = _process_saveat(saveat, tspan, save_start, save_end)
 
-    # Initialize current state and saved history
     u_current = copy(u0)
     u_new = similar(u0)
     t_current = tspan[1]
@@ -726,30 +743,31 @@ function DiffEqBase.solve(jump_prob::JumpProblem, alg::SimpleImplicitTauLeaping;
     du = similar(u0)
     t_end = tspan[2]
     epsilon = alg.epsilon
-    solver = alg.solver
 
-    # Extract net stoichiometry for state updates
     nu = zeros(float(eltype(u0)), length(u0), numjumps)
     for j in 1:numjumps
         for (spec_idx, stoch) in maj.net_stoch[j]
             nu[spec_idx, j] = stoch
         end
     end
-    # Extract reactant stoichiometry for hor and gi
     reactant_stoch = maj.reactant_stoch
     hor = compute_hor(reactant_stoch, numjumps)
     max_hor, max_stoich = precompute_reaction_conditions(
-        reactant_stoch, hor, length(u0), numjumps)
+        reactant_stoch, hor, length(u0), numjumps
+    )
 
     simple_implicit_tau_leaping_loop!(
         prob, alg, u_current, u_new, t_current, t_end, p, rng,
         rate, nu, hor, max_hor, max_stoich, numjumps, epsilon,
         dtmin, saveat_times, usave, tsave, du, counts, rate_cache, rate_current, maj,
-        solver, save_end)
+        save_end
+    )
 
-    sol = SciMLBase.build_solution(prob, alg, tsave, usave,
+    sol = SciMLBase.build_solution(
+        prob, alg, tsave, usave,
         calculate_error = false,
-        interp = SciMLBase.ConstantInterpolation(tsave, usave))
+        interp = SciMLBase.ConstantInterpolation(tsave, usave)
+    )
     return sol
 end
 

--- a/src/simple_regular_solve.jl
+++ b/src/simple_regular_solve.jl
@@ -76,6 +76,89 @@ end
 
 SimpleExplicitTauLeaping(; epsilon = 0.05) = SimpleExplicitTauLeaping(epsilon)
 
+"""
+$(TYPEDEF)
+
+Abstract supertype for the nonlinear formulations
+[`SimpleImplicitTauLeaping`](@ref) can solve at each step.
+"""
+abstract type AbstractImplicitSolver end
+
+"""
+$(TYPEDEF)
+
+Solve each implicit tau-leaping step in its unmodified, fully implicit form,
+
+```math
+X(t + \\tau) = X(t) + \\sum_j \\nu_j a_j(X(t + \\tau)) \\tau
+```
+
+as in Rathinam et al. (2003) and Cao et al. (2004).
+"""
+struct NewtonImplicitSolver <: AbstractImplicitSolver end
+
+"""
+$(TYPEDEF)
+
+Solve each implicit tau-leaping step in trapezoidal form, averaging the
+propensities at the current and the new state,
+
+```math
+X(t + \\tau) = X(t) + \\sum_j \\nu_j \\frac{a_j(X(t)) + a_j(X(t + \\tau))}{2} \\tau.
+```
+
+The trapezoidal formulation damps the excessive stiffness of the fully implicit
+step and keeps the equilibrium distribution closer to the exact one.
+"""
+struct TrapezoidalImplicitSolver <: AbstractImplicitSolver end
+
+"""
+$(TYPEDEF)
+
+An implicit tau-leaping method for stiff pure-jump problems.
+
+Explicit tau-leaping is limited by the fastest reaction in the system, so a
+stiff model forces a step size far smaller than the timescale of interest.
+Each step here instead solves a nonlinear equation for the new state, which
+lifts that restriction; see Rathinam et al. (2003) and Cao et al. (2004).
+
+The deterministic part of the step is taken implicitly and the fluctuations are
+then sampled with Poisson random variables, after which the step is rejected and
+`tau` halved if it would drive a population negative.
+
+## Fields
+
+$(FIELDS)
+
+## Notes
+
+  - Only works with `JumpProblem`s defined from `DiscreteProblem`s that contain
+    only a `MassActionJump`, built with the `PureLeaping()` aggregator.
+  - Supports `saveat`, `save_start` and `save_end`.
+
+## Examples
+
+```julia
+using JumpProcesses
+
+maj = MassActionJump([1.0, 1.0], [[1 => 1], [2 => 1]], [[1 => -1, 2 => 1], [1 => 1, 2 => -1]])
+prob = DiscreteProblem([100, 100], (0.0, 10.0))
+jprob = JumpProblem(prob, PureLeaping(), maj)
+sol = solve(jprob, SimpleImplicitTauLeaping())
+```
+"""
+struct SimpleImplicitTauLeaping{T <: AbstractFloat, S <: AbstractImplicitSolver} <:
+       SciMLBase.AbstractDEAlgorithm
+    """Error control parameter used when selecting `tau`."""
+    epsilon::T
+    """The nonlinear formulation solved at each step."""
+    solver::S
+end
+
+function SimpleImplicitTauLeaping(; epsilon = 0.05, solver = NewtonImplicitSolver())
+    SimpleImplicitTauLeaping(epsilon, solver)
+end
+
 function validate_pure_leaping_inputs(jump_prob::JumpProblem, alg)
     if !(jump_prob.aggregator isa PureLeaping)
         @warn "When using $alg, please pass PureLeaping() as the aggregator to the \
@@ -90,7 +173,8 @@ function validate_pure_leaping_inputs(jump_prob::JumpProblem, alg)
         jump_prob.regular_jump !== nothing
 end
 
-function validate_pure_leaping_inputs(jump_prob::JumpProblem, alg::SimpleExplicitTauLeaping)
+function validate_pure_leaping_inputs(jump_prob::JumpProblem,
+        alg::Union{SimpleExplicitTauLeaping, SimpleImplicitTauLeaping})
     if !(jump_prob.aggregator isa PureLeaping)
         @warn "When using $alg, please pass PureLeaping() as the aggregator to the \
         JumpProblem, i.e. call JumpProblem(::DiscreteProblem, PureLeaping(),...). \
@@ -468,6 +552,200 @@ function DiffEqBase.solve(jump_prob::JumpProblem, alg::SimpleExplicitTauLeaping;
         rate, c, nu, hor, max_hor, max_stoich, numjumps, epsilon,
         dtmin, saveat_times, usave, tsave, du, counts, rate_cache, rate_effective, maj,
         save_end)
+
+    sol = SciMLBase.build_solution(prob, alg, tsave, usave,
+        calculate_error = false,
+        interp = SciMLBase.ConstantInterpolation(tsave, usave))
+    return sol
+end
+
+# Residual of the implicit step, written so that the root u_new is the state at
+# t + tau. `params` carries a preallocated propensity cache for each of the two
+# states so that repeated residual evaluations do not allocate.
+#
+#   Newton:      u_new = u_current + sum_j nu_j a_j(u_new) tau
+#   Trapezoidal: u_new = u_current + sum_j nu_j (a_j(u_current) + a_j(u_new))/2 tau
+function implicit_equation!(resid, u_new, params)
+    (; u_current, rate_new, rate_current, nu, p, t, tau, rate, numjumps, solver) = params
+
+    rate(rate_new, u_new, p, t + tau)
+    resid .= u_new .- u_current
+
+    if solver isa NewtonImplicitSolver
+        for j in 1:numjumps
+            for spec_idx in axes(nu, 1)
+                resid[spec_idx] -= nu[spec_idx, j] * rate_new[j] * tau
+            end
+        end
+    else
+        rate(rate_current, u_current, p, t)
+        half = one(eltype(rate_new)) / 2
+        for j in 1:numjumps
+            for spec_idx in axes(nu, 1)
+                resid[spec_idx] -= nu[spec_idx, j] * half *
+                                   (rate_new[j] + rate_current[j]) * tau
+            end
+        end
+    end
+    nothing
+end
+
+# Solve one implicit step for the state at t + tau. Returns the new state and
+# whether the nonlinear solve converged.
+function solve_implicit(u_current, rate_new, rate_current, nu, p, t, tau, rate, numjumps,
+        solver)
+    u_guess = convert(Vector{float(eltype(u_current))}, u_current)
+    params = (; u_current, rate_new, rate_current, nu, p, t, tau, rate, numjumps, solver)
+    prob = NonlinearProblem(implicit_equation!, u_guess, params)
+    sol = solve(prob, SimpleNewtonRaphson(autodiff = AutoFiniteDiff());
+        abstol = 1e-6, reltol = 1e-6)
+    return sol.u, SciMLBase.successful_retcode(sol)
+end
+
+function simple_implicit_tau_leaping_loop!(
+        prob, alg, u_current, u_new, t_current, t_end, p, rng,
+        rate, nu, hor, max_hor, max_stoich, numjumps, epsilon,
+        dtmin, saveat_times, usave, tsave, du, counts, rate_cache, rate_current, maj,
+        solver, save_end)
+    save_idx = 1
+
+    # Upper bound carried across iterations. Unlike the explicit loop, whose
+    # retries redraw the Poisson counts, the implicit solve is deterministic in
+    # (u_current, tau): retrying at an unchanged tau would fail identically, so a
+    # rejected step has to shrink this bound to make progress.
+    tau_cap = typemax(typeof(t_current))
+
+    while t_current < t_end
+        rate(rate_cache, u_current, p, t_current)
+        if all(<=(0), rate_cache)  # No reactions can occur, step to final time
+            t_current = t_end
+            break
+        end
+        tau = compute_tau(u_current, rate_cache, nu, hor, p, t_current,
+            epsilon, rate, dtmin, max_hor, max_stoich, numjumps)
+        tau = min(tau, tau_cap, t_end - t_current)
+        if !isempty(saveat_times) && save_idx <= length(saveat_times) &&
+           t_current + tau > saveat_times[save_idx]
+            tau = saveat_times[save_idx] - t_current
+        end
+
+        u_predicted, converged = solve_implicit(u_current, rate_cache, rate_current, nu, p,
+            t_current, tau, rate, numjumps, solver)
+        if !converged
+            tau <= dtmin &&
+                error("SimpleImplicitTauLeaping failed to converge at t = $t_current " *
+                      "with the smallest permitted step dtmin = $dtmin.")
+            tau_cap = tau / 2
+            continue
+        end
+
+        # Sample the leap using the propensities at the implicitly predicted state.
+        rate(rate_cache, u_predicted, p, t_current + tau)
+        for j in eachindex(counts)
+            scaled = rate_cache[j] * tau
+            counts[j] = scaled <= zero(scaled) ? zero(eltype(counts)) :
+                        pois_rand(rng, scaled)
+        end
+
+        du .= 0
+        for j in 1:numjumps
+            for (spec_idx, stoch) in maj.net_stoch[j]
+                du[spec_idx] += stoch * counts[j]
+            end
+        end
+        u_new .= u_current .+ du
+        if any(<(0), u_new)
+            # Halve tau to avoid negative populations, as per Cao et al. (2006), Section 3.3
+            tau <= dtmin && break
+            tau_cap = tau / 2
+            continue
+        end
+        t_new = t_current + tau
+
+        # Save state if at a saveat time or if saveat is empty
+        if isempty(saveat_times) ||
+           (save_idx <= length(saveat_times) && t_new >= saveat_times[save_idx])
+            push!(usave, copy(u_new))
+            push!(tsave, t_new)
+            if !isempty(saveat_times) && t_new >= saveat_times[save_idx]
+                save_idx += 1
+            end
+        end
+
+        u_current .= u_new
+        t_current = t_new
+        tau_cap = typemax(typeof(t_current))  # release the bound after a good step
+    end
+
+    # Save endpoint if requested and not already saved
+    if save_end && (isempty(tsave) || tsave[end] != t_end)
+        push!(usave, copy(u_current))
+        push!(tsave, t_end)
+    end
+end
+
+function DiffEqBase.solve(jump_prob::JumpProblem, alg::SimpleImplicitTauLeaping;
+        seed = nothing,
+        dtmin = nothing,
+        saveat = nothing, save_start = nothing, save_end = nothing)
+    validate_pure_leaping_inputs(jump_prob, alg) ||
+        error("SimpleImplicitTauLeaping can only be used with PureLeaping JumpProblem with a MassActionJump.")
+
+    prob = jump_prob.prob
+    rng = jump_prob.rng
+    tspan = prob.tspan
+
+    if dtmin === nothing
+        dtmin = 1e-10 * one(typeof(tspan[2]))
+    end
+
+    (seed !== nothing) && seed!(rng, seed)
+
+    maj = jump_prob.massaction_jump
+    numjumps = get_num_majumps(maj)
+    rate = massaction_rate(maj, numjumps)
+    u0 = copy(prob.u0)
+    p = prob.p
+
+    saveat_times, save_start, save_end = _process_saveat(saveat, tspan, save_start, save_end)
+
+    # Initialize current state and saved history
+    u_current = copy(u0)
+    u_new = similar(u0)
+    t_current = tspan[1]
+    if save_start
+        usave = [copy(u0)]
+        tsave = [tspan[1]]
+    else
+        usave = typeof(u0)[]
+        tsave = typeof(tspan[1])[]
+    end
+    rate_cache = zeros(float(eltype(u0)), numjumps)
+    rate_current = similar(rate_cache)
+    counts = zero(rate_cache)
+    du = similar(u0)
+    t_end = tspan[2]
+    epsilon = alg.epsilon
+    solver = alg.solver
+
+    # Extract net stoichiometry for state updates
+    nu = zeros(float(eltype(u0)), length(u0), numjumps)
+    for j in 1:numjumps
+        for (spec_idx, stoch) in maj.net_stoch[j]
+            nu[spec_idx, j] = stoch
+        end
+    end
+    # Extract reactant stoichiometry for hor and gi
+    reactant_stoch = maj.reactant_stoch
+    hor = compute_hor(reactant_stoch, numjumps)
+    max_hor, max_stoich = precompute_reaction_conditions(
+        reactant_stoch, hor, length(u0), numjumps)
+
+    simple_implicit_tau_leaping_loop!(
+        prob, alg, u_current, u_new, t_current, t_end, p, rng,
+        rate, nu, hor, max_hor, max_stoich, numjumps, epsilon,
+        dtmin, saveat_times, usave, tsave, du, counts, rate_cache, rate_current, maj,
+        solver, save_end)
 
     sol = SciMLBase.build_solution(prob, alg, tsave, usave,
         calculate_error = false,

--- a/test/extended_jump_array.jl
+++ b/test/extended_jump_array.jl
@@ -1,5 +1,6 @@
 using Test, JumpProcesses, DiffEqBase, OrdinaryDiffEq, SciMLBase, LinearAlgebra, LinearSolve
 using FastBroadcast
+using ForwardDiff
 using StableRNGs
 
 rng = StableRNG(123)
@@ -11,6 +12,18 @@ old_norm = Base.FastMath.sqrt_fast(DiffEqBase.UNITLESS_ABS2(rand_array) /
                                    max(DiffEqBase.recursive_length(rand_array), 1))
 new_norm = DiffEqBase.ODE_DEFAULT_NORM(rand_array, 0.0)
 @test old_norm ≈ new_norm
+
+dual_array = ExtendedJumpArray(
+    ForwardDiff.Dual.(rand(rng, 5), 1.0),
+    ForwardDiff.Dual.(rand(rng, 2), 1.0)
+)
+dual_norm = DiffEqBase.ODE_DEFAULT_NORM(dual_array, ForwardDiff.Dual(0.0, 1.0))
+@test ForwardDiff.value(dual_norm) ≈ DiffEqBase.ODE_DEFAULT_NORM(
+    ExtendedJumpArray(
+        ForwardDiff.value.(dual_array.u),
+        ForwardDiff.value.(dual_array.jump_u)
+    ), 0.0
+)
 
 # Check for an ExtendedJumpArray where the types differ (Float64/Int64)
 rand_array = ExtendedJumpArray{Float64, 1, Vector{Float64}, Vector{Int64}}(rand(rng, 5),

--- a/test/regular_jumps.jl
+++ b/test/regular_jumps.jl
@@ -61,7 +61,7 @@ end
     sol_simple = solve(EnsembleProblem(jump_prob_tau), SimpleTauLeaping(), EnsembleSerial();
         trajectories = Nsims, dt = 0.1, saveat = t_compare)
 
-    # MassActionJump formulation for SimpleExplicitTauLeaping
+    # MassActionJump formulation for SimpleExplicitTauLeaping / SimpleImplicitTauLeaping
     reactant_stoich = [[1 => 1, 2 => 1], [2 => 1], Pair{Int, Int}[]]
     net_stoich = [[1 => -1, 2 => 1], [2 => -1, 3 => 1], [1 => 1]]
     param_idxs = [1, 2, 3]
@@ -73,13 +73,25 @@ end
         trajectories = Nsims, saveat = t_compare)
 
     # Compute mean I trajectories via direct indexing (I is index 2 in SIR)
+    # Solve with SimpleImplicitTauLeaping (Newton and Trapezoidal)
+    sol_implicit_newton = solve(EnsembleProblem(jump_prob_maj),
+        SimpleImplicitTauLeaping(solver = NewtonImplicitSolver()), EnsembleSerial();
+        trajectories = Nsims, saveat = t_compare)
+    sol_implicit_trap = solve(EnsembleProblem(jump_prob_maj),
+        SimpleImplicitTauLeaping(solver = TrapezoidalImplicitSolver()), EnsembleSerial();
+        trajectories = Nsims, saveat = t_compare)
+
     mean_I_direct = compute_mean_at_saves(sol_direct, Nsims, npts, 2)
     mean_I_simple = compute_mean_at_saves(sol_simple, Nsims, npts, 2)
     mean_I_explicit = compute_mean_at_saves(sol_adaptive, Nsims, npts, 2)
+    mean_I_implicit_newton = compute_mean_at_saves(sol_implicit_newton, Nsims, npts, 2)
+    mean_I_implicit_trap = compute_mean_at_saves(sol_implicit_trap, Nsims, npts, 2)
 
     # Compare full mean trajectories across all saved timepoints
     @test all(isapprox.(mean_I_direct, mean_I_simple, rtol = 0.1))
     @test all(isapprox.(mean_I_direct, mean_I_explicit, rtol = 0.1))
+    @test all(isapprox.(mean_I_direct, mean_I_implicit_newton, rtol = 0.1))
+    @test all(isapprox.(mean_I_direct, mean_I_implicit_trap, rtol = 0.1))
 end
 
 # SEIR model with exposed compartment
@@ -127,7 +139,7 @@ end
     sol_simple = solve(EnsembleProblem(jump_prob_tau), SimpleTauLeaping(), EnsembleSerial();
         trajectories = Nsims, dt = 0.1, saveat = t_compare)
 
-    # MassActionJump formulation for SimpleExplicitTauLeaping
+    # MassActionJump formulation for SimpleExplicitTauLeaping / SimpleImplicitTauLeaping
     reactant_stoich = [[1 => 1, 3 => 1], [2 => 1], [3 => 1]]
     net_stoich = [[1 => -1, 2 => 1], [2 => -1, 3 => 1], [3 => -1, 4 => 1]]
     param_idxs = [1, 2, 3]
@@ -139,13 +151,25 @@ end
         trajectories = Nsims, saveat = t_compare)
 
     # Compute mean I trajectories via direct indexing (I is index 3 in SEIR)
+    # Solve with SimpleImplicitTauLeaping (Newton and Trapezoidal)
+    sol_implicit_newton = solve(EnsembleProblem(jump_prob_maj),
+        SimpleImplicitTauLeaping(solver = NewtonImplicitSolver()), EnsembleSerial();
+        trajectories = Nsims, saveat = t_compare)
+    sol_implicit_trap = solve(EnsembleProblem(jump_prob_maj),
+        SimpleImplicitTauLeaping(solver = TrapezoidalImplicitSolver()), EnsembleSerial();
+        trajectories = Nsims, saveat = t_compare)
+
     mean_I_direct = compute_mean_at_saves(sol_direct, Nsims, npts, 3)
     mean_I_simple = compute_mean_at_saves(sol_simple, Nsims, npts, 3)
     mean_I_explicit = compute_mean_at_saves(sol_adaptive, Nsims, npts, 3)
+    mean_I_implicit_newton = compute_mean_at_saves(sol_implicit_newton, Nsims, npts, 3)
+    mean_I_implicit_trap = compute_mean_at_saves(sol_implicit_trap, Nsims, npts, 3)
 
     # Compare full mean trajectories across all saved timepoints
     @test all(isapprox.(mean_I_direct, mean_I_simple, rtol = 0.1))
     @test all(isapprox.(mean_I_direct, mean_I_explicit, rtol = 0.1))
+    @test all(isapprox.(mean_I_direct, mean_I_implicit_newton, rtol = 0.1))
+    @test all(isapprox.(mean_I_direct, mean_I_implicit_trap, rtol = 0.1))
 end
 
 # Test zero-rate case for SimpleExplicitTauLeaping

--- a/test/regular_jumps.jl
+++ b/test/regular_jumps.jl
@@ -3,6 +3,9 @@ using Test, LinearAlgebra, Statistics
 using StableRNGs
 rng = StableRNG(12345)
 
+@test SimpleImplicitTauLeaping().epsilon == 0.05
+@test SimpleTrapezoidalLeaping().epsilon == 0.05
+
 Nsims = 1000
 t_compare = 0.0:10.0:250.0
 npts = length(t_compare)
@@ -61,7 +64,7 @@ end
     sol_simple = solve(EnsembleProblem(jump_prob_tau), SimpleTauLeaping(), EnsembleSerial();
         trajectories = Nsims, dt = 0.1, saveat = t_compare)
 
-    # MassActionJump formulation for SimpleExplicitTauLeaping / SimpleImplicitTauLeaping
+    # MassActionJump formulation for adaptive tau-leaping algorithms
     reactant_stoich = [[1 => 1, 2 => 1], [2 => 1], Pair{Int, Int}[]]
     net_stoich = [[1 => -1, 2 => 1], [2 => -1, 3 => 1], [1 => 1]]
     param_idxs = [1, 2, 3]
@@ -73,25 +76,28 @@ end
         trajectories = Nsims, saveat = t_compare)
 
     # Compute mean I trajectories via direct indexing (I is index 2 in SIR)
-    # Solve with SimpleImplicitTauLeaping (Newton and Trapezoidal)
-    sol_implicit_newton = solve(EnsembleProblem(jump_prob_maj),
-        SimpleImplicitTauLeaping(solver = NewtonImplicitSolver()), EnsembleSerial();
-        trajectories = Nsims, saveat = t_compare)
-    sol_implicit_trap = solve(EnsembleProblem(jump_prob_maj),
-        SimpleImplicitTauLeaping(solver = TrapezoidalImplicitSolver()), EnsembleSerial();
-        trajectories = Nsims, saveat = t_compare)
+    sol_implicit = solve(
+        EnsembleProblem(jump_prob_maj),
+        SimpleImplicitTauLeaping(), EnsembleSerial();
+        trajectories = Nsims, saveat = t_compare
+    )
+    sol_trapezoidal = solve(
+        EnsembleProblem(jump_prob_maj),
+        SimpleTrapezoidalLeaping(), EnsembleSerial();
+        trajectories = Nsims, saveat = t_compare
+    )
 
     mean_I_direct = compute_mean_at_saves(sol_direct, Nsims, npts, 2)
     mean_I_simple = compute_mean_at_saves(sol_simple, Nsims, npts, 2)
     mean_I_explicit = compute_mean_at_saves(sol_adaptive, Nsims, npts, 2)
-    mean_I_implicit_newton = compute_mean_at_saves(sol_implicit_newton, Nsims, npts, 2)
-    mean_I_implicit_trap = compute_mean_at_saves(sol_implicit_trap, Nsims, npts, 2)
+    mean_I_implicit = compute_mean_at_saves(sol_implicit, Nsims, npts, 2)
+    mean_I_trapezoidal = compute_mean_at_saves(sol_trapezoidal, Nsims, npts, 2)
 
     # Compare full mean trajectories across all saved timepoints
     @test all(isapprox.(mean_I_direct, mean_I_simple, rtol = 0.1))
     @test all(isapprox.(mean_I_direct, mean_I_explicit, rtol = 0.1))
-    @test all(isapprox.(mean_I_direct, mean_I_implicit_newton, rtol = 0.1))
-    @test all(isapprox.(mean_I_direct, mean_I_implicit_trap, rtol = 0.1))
+    @test all(isapprox.(mean_I_direct, mean_I_implicit, rtol = 0.1))
+    @test all(isapprox.(mean_I_direct, mean_I_trapezoidal, rtol = 0.1))
 end
 
 # SEIR model with exposed compartment
@@ -139,7 +145,7 @@ end
     sol_simple = solve(EnsembleProblem(jump_prob_tau), SimpleTauLeaping(), EnsembleSerial();
         trajectories = Nsims, dt = 0.1, saveat = t_compare)
 
-    # MassActionJump formulation for SimpleExplicitTauLeaping / SimpleImplicitTauLeaping
+    # MassActionJump formulation for adaptive tau-leaping algorithms
     reactant_stoich = [[1 => 1, 3 => 1], [2 => 1], [3 => 1]]
     net_stoich = [[1 => -1, 2 => 1], [2 => -1, 3 => 1], [3 => -1, 4 => 1]]
     param_idxs = [1, 2, 3]
@@ -151,25 +157,28 @@ end
         trajectories = Nsims, saveat = t_compare)
 
     # Compute mean I trajectories via direct indexing (I is index 3 in SEIR)
-    # Solve with SimpleImplicitTauLeaping (Newton and Trapezoidal)
-    sol_implicit_newton = solve(EnsembleProblem(jump_prob_maj),
-        SimpleImplicitTauLeaping(solver = NewtonImplicitSolver()), EnsembleSerial();
-        trajectories = Nsims, saveat = t_compare)
-    sol_implicit_trap = solve(EnsembleProblem(jump_prob_maj),
-        SimpleImplicitTauLeaping(solver = TrapezoidalImplicitSolver()), EnsembleSerial();
-        trajectories = Nsims, saveat = t_compare)
+    sol_implicit = solve(
+        EnsembleProblem(jump_prob_maj),
+        SimpleImplicitTauLeaping(), EnsembleSerial();
+        trajectories = Nsims, saveat = t_compare
+    )
+    sol_trapezoidal = solve(
+        EnsembleProblem(jump_prob_maj),
+        SimpleTrapezoidalLeaping(), EnsembleSerial();
+        trajectories = Nsims, saveat = t_compare
+    )
 
     mean_I_direct = compute_mean_at_saves(sol_direct, Nsims, npts, 3)
     mean_I_simple = compute_mean_at_saves(sol_simple, Nsims, npts, 3)
     mean_I_explicit = compute_mean_at_saves(sol_adaptive, Nsims, npts, 3)
-    mean_I_implicit_newton = compute_mean_at_saves(sol_implicit_newton, Nsims, npts, 3)
-    mean_I_implicit_trap = compute_mean_at_saves(sol_implicit_trap, Nsims, npts, 3)
+    mean_I_implicit = compute_mean_at_saves(sol_implicit, Nsims, npts, 3)
+    mean_I_trapezoidal = compute_mean_at_saves(sol_trapezoidal, Nsims, npts, 3)
 
     # Compare full mean trajectories across all saved timepoints
     @test all(isapprox.(mean_I_direct, mean_I_simple, rtol = 0.1))
     @test all(isapprox.(mean_I_direct, mean_I_explicit, rtol = 0.1))
-    @test all(isapprox.(mean_I_direct, mean_I_implicit_newton, rtol = 0.1))
-    @test all(isapprox.(mean_I_direct, mean_I_implicit_trap, rtol = 0.1))
+    @test all(isapprox.(mean_I_direct, mean_I_implicit, rtol = 0.1))
+    @test all(isapprox.(mean_I_direct, mean_I_trapezoidal, rtol = 0.1))
 end
 
 # Test zero-rate case for SimpleExplicitTauLeaping


### PR DESCRIPTION
## What changed and why

This carries forward all implementation work from https://github.com/SciML/JumpProcesses.jl/pull/500 and finishes the API requested in https://github.com/SciML/JumpProcesses.jl/pull/500#discussion_r3879453636. The fully implicit and trapezoidal formulations are now separate algorithms, `SimpleImplicitTauLeaping()` and `SimpleTrapezoidalLeaping()`, instead of one algorithm selected through public solver-marker types.

Loading `SimpleNonlinearSolve` also activates DiffEqBase's ForwardDiff extension and exposed an `ODE_DEFAULT_NORM` ambiguity with `ExtendedJumpArray`. A narrow ForwardDiff extension now resolves that method intersection by invoking the existing `ExtendedJumpArray` norm implementation. ForwardDiff is added only as a weak dependency and test extra; ForwardDiff and JumpProcesses both use MIT-family permissive licenses.

## Failing before / passing after

### Algorithm naming

On the carried-forward implementation before the finishing commit:

```text
$ julia +1.10.12 --project=. -e 'using Test, JumpProcesses; @test SimpleImplicitTauLeaping().epsilon == 0.05; @test SimpleTrapezoidalLeaping().epsilon == 0.05'
Error During Test at none:1
  Expression: (SimpleTrapezoidalLeaping()).epsilon == 0.05
  UndefVarError: `SimpleTrapezoidalLeaping` not defined
ERROR: There was an error during testing
```

The same command exits successfully with this PR.

### QA ambiguity

With only the carried-forward commit applied, the exact QA command failed:

```text
$ GROUP=QA julia +1.10.12 --project=. -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Fail  Total
QA Tests      |   17     1     18

Ambiguity #1
ODE_DEFAULT_NORM(u::AbstractArray{<:ForwardDiff.Dual{Tag, T}}, ::ForwardDiff.Dual)
ODE_DEFAULT_NORM(u::JumpProcesses.ExtendedJumpArray, t)
```

With the ForwardDiff extension in this PR, the same command reports:

```text
Test Summary: | Pass  Total   Time
QA Tests      |   18     18  40.9s
Testing JumpProcesses tests passed
```

## Verification

```text
$ GROUP=InterfaceI julia +1.10.12 --project=. -e 'using Pkg; Pkg.test()'
ExtendedJumpArray Tests |   30     30  34.7s
Tau Leaping Tests       |   51     51  1m22.6s
Extinction test         |  292    292  8.5s
1200.513357 seconds
Testing JumpProcesses tests passed

$ GROUP=QA julia +1.10.12 --project=. -e 'using Pkg; Pkg.test()'
QA Tests | 18/18
Testing JumpProcesses tests passed

$ julia +1.10.12 --project=docs docs/make.jl
[ Info: CrossReferences: building cross-references.
[ Info: CheckDocument: running document checks.
[ Info: RenderDocument: rendering document.
exit code 0

$ julia +release --project=/home/crackauc/.julia/environments/v1.12 -m Runic --version
runic version 1.9.0, julia version 1.12.6

$ typos Project.toml docs/src/api.md ext/JumpProcessesForwardDiffExt.jl src/JumpProcesses.jl src/simple_regular_solve.jl test/extended_jump_array.jl test/regular_jumps.jl
exit code 0

$ git diff --check
exit code 0
```

Runic 1.9.0 was applied in line-scoped mode to every added or changed Julia block. The repository has pre-existing whole-file Runic drift, so unrelated formatting was not included in this behavior PR.

## Not verified locally

- `InterfaceII`, `Everything`, downstream, and other Julia-version groups were not run.
- CUDA/GPU jobs were not run because this change does not touch GPU code and no GPU validation was attempted.

## Review hold

Please ignore this draft until it has been reviewed by @ChrisRackauckas.

🤖 Generated with Codex (version unknown) (model: unknown). Session: local session ID `01a047ad-b125-77f3-933b-a29682b288ea`.
