### PR TITLE
Promote ADTypes to a runtime dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 version = "9.30.1"
 
 [deps]
+ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
@@ -63,7 +64,6 @@ Test = "1"
 julia = "1.10"
 
 [extras]
-ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 LinearSolve = "7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
@@ -78,4 +78,4 @@ StochasticDiffEq = "789caeaf-c7a9-5a7d-9973-96adeb23e2a0"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["ADTypes", "FastBroadcast", "LinearAlgebra", "LinearSolve", "OrdinaryDiffEq", "OrdinaryDiffEqFunctionMap", "Pkg", "SafeTestsets", "SciMLTesting", "StableRNGs", "Statistics", "StochasticDiffEq", "Test"]
+test = ["FastBroadcast", "LinearAlgebra", "LinearSolve", "OrdinaryDiffEq", "OrdinaryDiffEqFunctionMap", "Pkg", "SafeTestsets", "SciMLTesting", "StableRNGs", "Statistics", "StochasticDiffEq", "Test"]


### PR DESCRIPTION
## What changed and why

Move `ADTypes` from the test-only extras/target into runtime dependencies. This is a focused prerequisite for selecting `AutoFiniteDiff()` in the implicit tau-leaping implementation in https://github.com/SciML/JumpProcesses.jl/pull/643.

`ADTypes` already had a runtime-compatible `[compat]` entry. Its license is MIT, matching JumpProcesses.jl.

Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Verification

```text
$ TMPDIR=/home/crackauc/tmp GROUP=QA julia +1.10.12 --project=. -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total   Time
QA Tests      |   18     18  41.1s
Testing JumpProcesses tests passed
```

```text
$ typos Project.toml
# exit 0

$ git diff --check
# exit 0
```

No source or public API behavior changes in this PR. Documentation, InterfaceI, GPU, downstream, and other Julia versions were not run because the diff only reclassifies an existing test dependency as a runtime dependency.

🤖 Generated with Codex (version unknown) (model: unknown), session: local session ID 01a047ad-b125-77f3-933b-a29682b288ea
